### PR TITLE
Skipping project creation when the project creation is disabled

### DIFF
--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -217,6 +217,7 @@ def _set_project():
     enable_project_creation = project_settings["max"].get("enabled_project_creation")
     if not enable_project_creation:
         log.debug("Project creation disabled. Skipping project creation.")
+        return
     workdir = os.getenv("AYON_WORKDIR")
 
     os.makedirs(workdir, exist_ok=True)


### PR DESCRIPTION
## Changelog Description
This PR is to fix the bug of project creation still happened when the project creation is disabled

## Additional info
n/a


## Testing notes:

1. Disable project creation in `ayon+settings://max/mxp_workspace/enabled_project_creation`
2. Launch Max
3. It won't create the folder
