### PR TITLE
Make sure multicamera render uses correct camera

### DIFF
--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -40,6 +40,7 @@ class RenderProducts(object):
     def get_multiple_beauty(self, outputs, cameras):
         beauty_output_frames = dict()
         for output, camera in zip(outputs, cameras):
+            camera = camera.replace(":", "_")
             filename, ext = os.path.splitext(output)
             filename = filename.replace(".", "")
             ext = ext.replace(".", "")
@@ -59,6 +60,7 @@ class RenderProducts(object):
         renderer = str(renderer_class).split(":")[0]
         aovs_frames = {}
         for output, camera in zip(outputs, cameras):
+            camera = camera.replace(":", "_")
             filename, ext = os.path.splitext(output)
             filename = filename.replace(".", "")
             ext = ext.replace(".", "")

--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -181,6 +181,7 @@ class RenderSettings(object):
         for i in range(render_elem_num):
             renderlayer_name = render_elem.GetRenderElement(i)
             target, renderpass = str(renderlayer_name).split(":")
+            camera = camera.replace(":", "_")
             aov_name = f"{output}_{camera}_{renderpass}..{img_fmt}"
             render_element_list.append(aov_name)
         return render_element_list
@@ -222,6 +223,7 @@ class RenderSettings(object):
                 renderlayer = rt.batchRenderMgr.GetView(layer_no)
             # use camera name as renderlayer name
             renderlayer.name = cam
+            cam = cam.replace(":", "_")
             renderlayer.outputFilename = f"{output}_{cam}..{img_fmt}"
             outputs.append(renderlayer.outputFilename)
         return outputs

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -67,7 +67,8 @@ class CollectRender(pyblish.api.InstancePlugin):
             instance.data["files"] = list()
             instance.data["expectedFiles"].append(files_by_aov)
             instance.data["files"].append(files_by_aov)
-
+        self.log.debug("expectedFiles")
+        self.log.debug(instance.data["expectedFiles"])
         img_format = RenderProducts().image_format()
         # OCIO config not support in
         # most of the 3dsmax renderers

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -67,8 +67,6 @@ class CollectRender(pyblish.api.InstancePlugin):
             instance.data["files"] = list()
             instance.data["expectedFiles"].append(files_by_aov)
             instance.data["files"].append(files_by_aov)
-        self.log.debug("expectedFiles")
-        self.log.debug(instance.data["expectedFiles"])
         img_format = RenderProducts().image_format()
         # OCIO config not support in
         # most of the 3dsmax renderers

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -55,9 +55,8 @@ filename = "{filename}"
 new_filepath = "{new_filepath}"
 new_output = "{new_output}"
 camera = "{camera}"
-target_cam = next((c for c in rt.Objects if rt.Classof(c) in rt.Camera.classes and c.name == camera), None)
-if target_cam:
-    rt.viewport.setCamera(target_cam)
+target_camera_node = rt.getNodeByName(camera)
+rt.viewport.setCamera(target_camera_node)
 rt.rendOutputFilename = new_output
 directory = os.path.dirname(rt.rendOutputFilename)
 directory = os.path.join(directory, filename)

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -26,6 +26,7 @@ class SaveScenesForCamera(pyblish.api.InstancePlugin):
                 "Multi Camera disabled. "
                 "Skipping to save scene files for cameras")
             return
+        self.log.debug(f"system platform:{sys.platform}")
         current_folder = rt.maxFilePath
         current_filename = rt.maxFileName
         current_filepath = os.path.join(current_folder, current_filename)
@@ -82,7 +83,8 @@ rt.saveMaxFile(new_filepath)
             os.path.dirname(sys.executable), "3dsmaxbatch")
         maxbatch_exe = maxbatch_exe.replace("\\", "/")
         if sys.platform == "windows":
-            maxbatch_exe += ".exe"
+            maxbatch_exe = os.path.join(
+                os.path.dirname(sys.executable), "3dsmaxbatch.exe")
             maxbatch_exe = os.path.normpath(maxbatch_exe)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             tmp_script_path = os.path.join(

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -1,5 +1,6 @@
 import pyblish.api
 import os
+import sys
 import platform
 import tempfile
 

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -55,6 +55,9 @@ filename = "{filename}"
 new_filepath = "{new_filepath}"
 new_output = "{new_output}"
 camera = "{camera}"
+target_cam = next((c for c in rt.Objects if rt.Classof(c) in rt.Camera.classes and c.name == camera), None)
+if target_cam:
+    rt.viewport.setCamera(target_cam)
 rt.rendOutputFilename = new_output
 directory = os.path.dirname(rt.rendOutputFilename)
 directory = os.path.join(directory, filename)

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -43,7 +43,8 @@ class SaveScenesForCamera(pyblish.api.InstancePlugin):
         for camera in cameras:
             new_output = RenderSettings().get_batch_render_output(camera)       # noqa
             new_output = new_output.replace("\\", "/")
-            new_filename = f"{filename}_{camera}{ext}"
+            camera_name = camera.replace(":", "_")
+            new_filename = f"{filename}_{camera_name}{ext}"
             new_filepath = os.path.join(new_folder, new_filename)
             new_filepath = new_filepath.replace("\\", "/")
             camera_scene_files.append(new_filepath)
@@ -57,6 +58,7 @@ filename = "{filename}"
 new_filepath = "{new_filepath}"
 new_output = "{new_output}"
 camera = "{camera}"
+camera_name = camera.replace(":", "_")
 target_camera_node = rt.getNodeByName(camera)
 rt.viewport.setCamera(target_camera_node)
 rt.rendOutputFilename = new_output
@@ -71,7 +73,7 @@ if render_elem_num > 0:
     for i in range(render_elem_num):
         renderlayer_name = render_elem.GetRenderElement(i)
         target, renderpass = str(renderlayer_name).split(":")
-        aov_name =  f"{{directory}}_{camera}_{{renderpass}}..{ext}"
+        aov_name =  f"{{directory}}_{{camera_name}}_{{renderpass}}..{ext}"
         render_elem.SetRenderElementFileName(i, aov_name)
 rt.saveMaxFile(new_filepath)
         """).format(filename=instance.name,

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -59,6 +59,7 @@ target_camera_node = rt.getNodeByName(camera)
 rt.viewport.setCamera(target_camera_node)
 rt.rendOutputFilename = new_output
 directory = os.path.dirname(rt.rendOutputFilename)
+os.makedirs(directory, exist_ok=True)
 directory = os.path.join(directory, filename)
 render_elem = rt.maxOps.GetCurRenderElementMgr()
 render_elem_num = render_elem.NumRenderElements()
@@ -76,7 +77,6 @@ rt.saveMaxFile(new_filepath)
                     camera=camera,
                     ext=fmt)
             scripts.append(script)
-
         maxbatch_exe = os.path.join(
             os.path.dirname(sys.executable), "3dsmaxbatch")
         maxbatch_exe = maxbatch_exe.replace("\\", "/")
@@ -105,3 +105,4 @@ rt.saveMaxFile(new_filepath)
                 self.log.error("Camera scene files not existed yet!")
                 raise RuntimeError("MaxBatch.exe doesn't run as expected")
             self.log.debug(f"Found Camera scene:{camera_scene}")
+        self.log.debug(scripts)

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -76,6 +76,7 @@ rt.saveMaxFile(new_filepath)
                     new_output=new_output,
                     camera=camera,
                     ext=fmt)
+            self.log.log(script)
             scripts.append(script)
         maxbatch_exe = os.path.join(
             os.path.dirname(sys.executable), "3dsmaxbatch")
@@ -92,17 +93,13 @@ rt.saveMaxFile(new_filepath)
                 for script in scripts:
                     tmp.write(script + "\n")
 
-            try:
-                current_filepath = current_filepath.replace("\\", "/")
-                tmp_script_path = tmp_script_path.replace("\\", "/")
-                run_subprocess([maxbatch_exe, tmp_script_path,
-                                "-sceneFile", current_filepath])
-            except RuntimeError:
-                self.log.debug("Checking the scene files existing")
+            current_filepath = current_filepath.replace("\\", "/")
+            tmp_script_path = tmp_script_path.replace("\\", "/")
+            run_subprocess([maxbatch_exe, tmp_script_path,
+                            "-sceneFile", current_filepath])
 
         for camera_scene in camera_scene_files:
             if not os.path.exists(camera_scene):
                 self.log.error("Camera scene files not existed yet!")
                 raise RuntimeError("MaxBatch.exe doesn't run as expected")
             self.log.debug(f"Found Camera scene:{camera_scene}")
-        self.log.debug(scripts)

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -1,7 +1,8 @@
 import pyblish.api
 import os
-import sys
+import platform
 import tempfile
+
 
 from pymxs import runtime as rt
 from ayon_core.lib import run_subprocess
@@ -26,7 +27,6 @@ class SaveScenesForCamera(pyblish.api.InstancePlugin):
                 "Multi Camera disabled. "
                 "Skipping to save scene files for cameras")
             return
-        self.log.debug(f"system platform:{sys.platform}")
         current_folder = rt.maxFilePath
         current_filename = rt.maxFileName
         current_filepath = os.path.join(current_folder, current_filename)
@@ -82,9 +82,8 @@ rt.saveMaxFile(new_filepath)
         maxbatch_exe = os.path.join(
             os.path.dirname(sys.executable), "3dsmaxbatch")
         maxbatch_exe = maxbatch_exe.replace("\\", "/")
-        if sys.platform == "windows":
-            maxbatch_exe = os.path.join(
-                os.path.dirname(sys.executable), "3dsmaxbatch.exe")
+        if platform.system().lower() == "windows":
+            maxbatch_exe += ".exe"
             maxbatch_exe = os.path.normpath(maxbatch_exe)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             tmp_script_path = os.path.join(

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -59,8 +59,9 @@ target_camera_node = rt.getNodeByName(camera)
 rt.viewport.setCamera(target_camera_node)
 rt.rendOutputFilename = new_output
 directory = os.path.dirname(rt.rendOutputFilename)
-os.makedirs(directory, exist_ok=True)
 directory = os.path.join(directory, filename)
+if not os.path.exists(directory):
+    os.mkdir(directory)
 render_elem = rt.maxOps.GetCurRenderElementMgr()
 render_elem_num = render_elem.NumRenderElements()
 if render_elem_num > 0:
@@ -76,7 +77,6 @@ rt.saveMaxFile(new_filepath)
                     new_output=new_output,
                     camera=camera,
                     ext=fmt)
-            self.log.log(script)
             scripts.append(script)
         maxbatch_exe = os.path.join(
             os.path.dirname(sys.executable), "3dsmaxbatch")

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -95,8 +95,11 @@ rt.saveMaxFile(new_filepath)
 
             current_filepath = current_filepath.replace("\\", "/")
             tmp_script_path = tmp_script_path.replace("\\", "/")
+            full_script = "\n".join(scripts)
+            self.log.debug(f"Failed running script {tmp_script_path}:\n{full_script}")
             run_subprocess([maxbatch_exe, tmp_script_path,
-                            "-sceneFile", current_filepath])
+                            "-sceneFile", current_filepath],
+                            logger=self.log)
 
         for camera_scene in camera_scene_files:
             if not os.path.exists(camera_scene):

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -93,16 +93,18 @@ rt.saveMaxFile(new_filepath)
                 for script in scripts:
                     tmp.write(script + "\n")
 
-            current_filepath = current_filepath.replace("\\", "/")
-            tmp_script_path = tmp_script_path.replace("\\", "/")
             full_script = "\n".join(scripts)
             self.log.debug(f"Failed running script {tmp_script_path}:\n{full_script}")
+            current_filepath = current_filepath.replace("\\", "/")
+            tmp_script_path = tmp_script_path.replace("\\", "/")
             run_subprocess([maxbatch_exe, tmp_script_path,
                             "-sceneFile", current_filepath],
                             logger=self.log)
 
         for camera_scene in camera_scene_files:
             if not os.path.exists(camera_scene):
+                full_script = "\n".join(scripts)
+                self.log.debug(f"Failed running script {tmp_script_path}:\n{full_script}")
                 self.log.error("Camera scene files not existed yet!")
                 raise RuntimeError("MaxBatch.exe doesn't run as expected")
             self.log.debug(f"Found Camera scene:{camera_scene}")


### PR DESCRIPTION
## Changelog Description
This PR is to fix the bug of using same camera across the scenes when multicamera option is enabled.
Resolve https://github.com/ynput/ayon-3dsmax/issues/12

## Additional info
Test along with https://github.com/ynput/ayon-deadline/pull/47
## Testing notes:

1. Create Render Instance with multicamera option enabled
2. Publish
3. Check your published renders are with different cameras.
