### PR TITLE
Add setting for auto key default frame

### DIFF
--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -281,6 +281,12 @@ def reset_frame_range(fps: bool = True):
     set_render_frame_range(
         frame_range["frameStartHandle"], frame_range["frameEndHandle"])
 
+    project_name = get_current_project_name()
+    settings = get_project_settings(project_name).get("max")
+    auto_key_default_key_time = settings.get(
+        "auto_key_default", {}).get("defualt_key_time")
+    rt.maxOps.autoKeyDefaultKeyTime = auto_key_default_key_time
+
 
 def get_fps_for_current_context():
     """Get fps that should be set for current context.

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -38,6 +38,11 @@ class UnitScaleSettings(BaseSettingsModel):
     )
 
 
+class AutoKeyValueSettings(BaseSettingsModel):
+    defualt_key_time: int = SettingsField(
+        0, title="Auto Key Default Frame")
+
+
 class PRTAttributesModel(BaseSettingsModel):
     _layout = "compact"
     name: str = SettingsField(title="Name")
@@ -53,6 +58,10 @@ class MaxSettings(BaseSettingsModel):
     unit_scale_settings: UnitScaleSettings = SettingsField(
         default_factory=UnitScaleSettings,
         title="Set Unit Scale"
+    )
+    auto_key_default: AutoKeyValueSettings = SettingsField(
+        default_factory=AutoKeyValueSettings,
+        title="Auto Key Default Value"
     )
     mxp_workspace: MxpWorkspaceSettings = SettingsField(
         default_factory=MxpWorkspaceSettings,
@@ -106,6 +115,9 @@ DEFAULT_VALUES = {
     "mxp_workspace": {
         "enabled_project_creation": False,
         "mxp_workspace_script": DEFAULT_MXP_WORKSPACE_SETTINGS
+    },
+    "auto_key_default":{
+        "defualt_key_time": 0
     },
     "RenderSettings": DEFAULT_RENDER_SETTINGS,
     "CreateReview": DEFAULT_CREATE_REVIEW_SETTINGS,


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-3dsmax/issues/14
This PR is to add an option for setting auto key default frame in Animation Settings from Preferences in Ayon setting

## Additional info
n/a


## Testing notes:

1. Install and build the 3dmax Addon with this branch
2. Go to `ayon+settings://max/auto_key_default/defualt_key_time`
![image](https://github.com/user-attachments/assets/acfb74be-28ec-4e19-b5a0-66c4c94d8fc6)
3. Set your preferred default frame
4. Launch Max via Ayon
5. Ayon -> Set Frame Range
6. Go to File -> Preferences -> Animation
