### PR TITLE
Add project name as container data for loading and updating assets

### DIFF
--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -202,6 +202,7 @@ def containerise(name: str, nodes: list, context,
         "namespace": namespace or "",
         "loader": loader,
         "representation": context["representation"]["id"],
+        "project_name": context["project"]["name"]
     }
     container_name = f"{namespace}:{name}{suffix}"
     container = rt.container(name=container_name)

--- a/client/ayon_max/hooks/force_startup_script.py
+++ b/client/ayon_max/hooks/force_startup_script.py
@@ -15,6 +15,7 @@ class ForceStartupScript(PreLaunchHook):
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
     app_groups = {"3dsmax", "adsk_3dsmax"}
+    order = 11
     launch_types = {LaunchTypes.local}
 
     def execute(self):

--- a/client/ayon_max/hooks/force_startup_script.py
+++ b/client/ayon_max/hooks/force_startup_script.py
@@ -15,7 +15,6 @@ class ForceStartupScript(PreLaunchHook):
     Hook `GlobalHostDataHook` must be executed before this hook.
     """
     app_groups = {"3dsmax", "adsk_3dsmax"}
-    order = 11
     launch_types = {LaunchTypes.local}
 
     def execute(self):

--- a/client/ayon_max/plugins/load/load_camera_fbx.py
+++ b/client/ayon_max/plugins/load/load_camera_fbx.py
@@ -88,7 +88,8 @@ class FbxLoader(load.LoaderPlugin):
 
         update_custom_attribute_data(node, fbx_objects)
         lib.imprint(container["instance_node"], {
-            "representation": repre_entity["id"]
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
         })
 
     def switch(self, container, context):

--- a/client/ayon_max/plugins/load/load_camera_fbx.py
+++ b/client/ayon_max/plugins/load/load_camera_fbx.py
@@ -12,7 +12,7 @@ from ayon_max.api.pipeline import (
     update_custom_attribute_data,
     remove_container_data
 )
-from ayon_core.pipeline import get_representation_path, load
+from ayon_core.pipeline import load
 
 
 class FbxLoader(load.LoaderPlugin):
@@ -55,7 +55,7 @@ class FbxLoader(load.LoaderPlugin):
         from pymxs import runtime as rt
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node_name = container["instance_node"]
         node = rt.getNodeByName(node_name)
         namespace, _ = get_namespace(node_name)

--- a/client/ayon_max/plugins/load/load_max_scene.py
+++ b/client/ayon_max/plugins/load/load_max_scene.py
@@ -13,7 +13,7 @@ from ayon_max.api.pipeline import (
     update_custom_attribute_data,
     remove_container_data
 )
-from ayon_core.pipeline import get_representation_path, load
+from ayon_core.pipeline import load
 
 
 class MaterialDupOptionsWindow(QtWidgets.QDialog):
@@ -126,7 +126,7 @@ class MaxSceneLoader(load.LoaderPlugin):
         from pymxs import runtime as rt
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node_name = container["instance_node"]
         node = rt.getNodeByName(node_name)
         namespace, _ = get_namespace(node_name)

--- a/client/ayon_max/plugins/load/load_max_scene.py
+++ b/client/ayon_max/plugins/load/load_max_scene.py
@@ -166,7 +166,8 @@ class MaxSceneLoader(load.LoaderPlugin):
 
         update_custom_attribute_data(node, max_objects)
         lib.imprint(container["instance_node"], {
-            "representation": repre_entity["id"]
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
         })
 
     def switch(self, container, context):

--- a/client/ayon_max/plugins/load/load_model.py
+++ b/client/ayon_max/plugins/load/load_model.py
@@ -74,7 +74,7 @@ class ModelAbcLoader(load.LoaderPlugin):
         from pymxs import runtime as rt
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node = rt.GetNodeByName(container["instance_node"])
         node_list = [n for n in get_previous_loaded_object(node)
                      if rt.ClassOf(n) == rt.AlembicContainer]
@@ -89,10 +89,11 @@ class ModelAbcLoader(load.LoaderPlugin):
                     rt.Select(abc_con.Children)
                     for abc_obj in abc_con.Children:
                         abc_obj.source = path
-        lib.imprint(
-            container["instance_node"],
-            {"representation": repre_entity["id"]},
-        )
+
+        lib.imprint(container["instance_node"], {
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
+        })
 
     def switch(self, container, context):
         self.update(container, context)

--- a/client/ayon_max/plugins/load/load_model.py
+++ b/client/ayon_max/plugins/load/load_model.py
@@ -1,5 +1,5 @@
 import os
-from ayon_core.pipeline import load, get_representation_path
+from ayon_core.pipeline import load
 from ayon_max.api.pipeline import (
     containerise,
     get_previous_loaded_object,

--- a/client/ayon_max/plugins/load/load_model_fbx.py
+++ b/client/ayon_max/plugins/load/load_model_fbx.py
@@ -51,7 +51,7 @@ class FbxModelLoader(load.LoaderPlugin):
         from pymxs import runtime as rt
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node_name = container["instance_node"]
         node = rt.getNodeByName(node_name)
         if not node:
@@ -85,8 +85,10 @@ class FbxModelLoader(load.LoaderPlugin):
         with maintained_selection():
             rt.Select(node)
         update_custom_attribute_data(node, fbx_objects)
+
         lib.imprint(container["instance_node"], {
-            "representation": repre_entity["id"]
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
         })
 
     def switch(self, container, context):

--- a/client/ayon_max/plugins/load/load_model_fbx.py
+++ b/client/ayon_max/plugins/load/load_model_fbx.py
@@ -1,5 +1,5 @@
 import os
-from ayon_core.pipeline import load, get_representation_path
+from ayon_core.pipeline import load
 from ayon_max.api.pipeline import (
     containerise, get_previous_loaded_object,
     update_custom_attribute_data,

--- a/client/ayon_max/plugins/load/load_model_obj.py
+++ b/client/ayon_max/plugins/load/load_model_obj.py
@@ -50,7 +50,7 @@ class ObjLoader(load.LoaderPlugin):
         from pymxs import runtime as rt
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node_name = container["instance_node"]
         node = rt.getNodeByName(node_name)
         namespace, _ = get_namespace(node_name)
@@ -76,8 +76,9 @@ class ObjLoader(load.LoaderPlugin):
         with maintained_selection():
             rt.Select(node)
 
-        lib.imprint(node_name, {
-            "representation": repre_entity["id"]
+        lib.imprint(container["instance_node"], {
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
         })
 
     def switch(self, container, context):

--- a/client/ayon_max/plugins/load/load_model_obj.py
+++ b/client/ayon_max/plugins/load/load_model_obj.py
@@ -13,7 +13,7 @@ from ayon_max.api.pipeline import (
     update_custom_attribute_data,
     remove_container_data
 )
-from ayon_core.pipeline import get_representation_path, load
+from ayon_core.pipeline import load
 
 
 class ObjLoader(load.LoaderPlugin):

--- a/client/ayon_max/plugins/load/load_model_usd.py
+++ b/client/ayon_max/plugins/load/load_model_usd.py
@@ -16,7 +16,7 @@ from ayon_max.api.pipeline import (
     update_custom_attribute_data,
     remove_container_data
 )
-from ayon_core.pipeline import get_representation_path, load
+from ayon_core.pipeline import load
 
 
 class ModelUSDLoader(load.LoaderPlugin):
@@ -67,7 +67,7 @@ class ModelUSDLoader(load.LoaderPlugin):
 
     def update(self, container, context):
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node_name = container["instance_node"]
         node = rt.GetNodeByName(node_name)
         namespace, name = get_namespace(node_name)

--- a/client/ayon_max/plugins/load/load_model_usd.py
+++ b/client/ayon_max/plugins/load/load_model_usd.py
@@ -107,8 +107,9 @@ class ModelUSDLoader(load.LoaderPlugin):
         with maintained_selection():
             rt.Select(node)
 
-        lib.imprint(node_name, {
-            "representation": repre_entity["id"]
+        lib.imprint(container["instance_node"], {
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
         })
 
     def switch(self, container, context):

--- a/client/ayon_max/plugins/load/load_pointcache.py
+++ b/client/ayon_max/plugins/load/load_pointcache.py
@@ -5,7 +5,7 @@ Because of limited api, alembics can be only loaded, but not easily updated.
 
 """
 import os
-from ayon_core.pipeline import load, get_representation_path
+from ayon_core.pipeline import load
 from ayon_max.api import lib, maintained_selection
 from ayon_max.api.lib import unique_namespace, reset_frame_range
 from ayon_max.api.pipeline import (
@@ -83,7 +83,7 @@ class AbcLoader(load.LoaderPlugin):
         from pymxs import runtime as rt
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node = rt.GetNodeByName(container["instance_node"])
         abc_container = [n for n in get_previous_loaded_object(node)
                          if rt.ClassOf(n) == rt.AlembicContainer]

--- a/client/ayon_max/plugins/load/load_pointcache.py
+++ b/client/ayon_max/plugins/load/load_pointcache.py
@@ -98,10 +98,11 @@ class AbcLoader(load.LoaderPlugin):
                     rt.Select(abc_con.Children)
                     for abc_obj in abc_con.Children:
                         abc_obj.source = path
-        lib.imprint(
-            container["instance_node"],
-            {"representation": repre_entity["id"]},
-        )
+
+        lib.imprint(container["instance_node"], {
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
+        })
 
     def switch(self, container, context):
         self.update(container, context)

--- a/client/ayon_max/plugins/load/load_pointcache_ornatrix.py
+++ b/client/ayon_max/plugins/load/load_pointcache_ornatrix.py
@@ -97,10 +97,10 @@ class OxAbcLoader(load.LoaderPlugin):
                 abc.pos = transform_data[ox_transform] or 0
                 abc.scale = transform_data[f"{abc}.scale"] or 0
         update_custom_attribute_data(node, ox_abc_objects)
-        lib.imprint(
-            container["instance_node"],
-            {"representation": repre_entity["id"]},
-        )
+        lib.imprint(container["instance_node"], {
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
+        })
 
     def switch(self, container, context):
         self.update(container, context)

--- a/client/ayon_max/plugins/load/load_pointcache_ornatrix.py
+++ b/client/ayon_max/plugins/load/load_pointcache_ornatrix.py
@@ -1,5 +1,5 @@
 import os
-from ayon_core.pipeline import load, get_representation_path
+from ayon_core.pipeline import load
 from ayon_core.pipeline.load import LoadError
 from ayon_max.api.pipeline import (
     containerise,
@@ -64,7 +64,7 @@ class OxAbcLoader(load.LoaderPlugin):
 
     def update(self, container, context):
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node_name = container["instance_node"]
         namespace, name = get_namespace(node_name)
         node = rt.getNodeByName(node_name)

--- a/client/ayon_max/plugins/load/load_pointcloud.py
+++ b/client/ayon_max/plugins/load/load_pointcloud.py
@@ -11,7 +11,7 @@ from ayon_max.api.pipeline import (
     update_custom_attribute_data,
     remove_container_data
 )
-from ayon_core.pipeline import get_representation_path, load
+from ayon_core.pipeline import load
 
 
 class PointCloudLoader(load.LoaderPlugin):
@@ -46,7 +46,7 @@ class PointCloudLoader(load.LoaderPlugin):
         from pymxs import runtime as rt
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node = rt.GetNodeByName(container["instance_node"])
         node_list = get_previous_loaded_object(node)
         update_custom_attribute_data(

--- a/client/ayon_max/plugins/load/load_pointcloud.py
+++ b/client/ayon_max/plugins/load/load_pointcloud.py
@@ -55,8 +55,10 @@ class PointCloudLoader(load.LoaderPlugin):
             rt.Select(node_list)
             for prt in rt.Selection:
                 prt.filename = path
+
         lib.imprint(container["instance_node"], {
-            "representation": repre_entity["id"]
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
         })
 
     def switch(self, container, context):

--- a/client/ayon_max/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_max/plugins/load/load_redshift_proxy.py
@@ -66,7 +66,8 @@ class RedshiftProxyLoader(load.LoaderPlugin):
             proxy.file = path
 
         lib.imprint(container["instance_node"], {
-            "representation": repre_entity["id"]
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
         })
 
     def switch(self, container, context):

--- a/client/ayon_max/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_max/plugins/load/load_redshift_proxy.py
@@ -1,10 +1,7 @@
 import os
 import clique
 
-from ayon_core.pipeline import (
-    load,
-    get_representation_path
-)
+from ayon_core.pipeline import load
 from ayon_core.pipeline.load import LoadError
 from ayon_max.api.pipeline import (
     containerise,
@@ -56,7 +53,7 @@ class RedshiftProxyLoader(load.LoaderPlugin):
         from pymxs import runtime as rt
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node = rt.getNodeByName(container["instance_node"])
         node_list = get_previous_loaded_object(node)
         rt.Select(node_list)

--- a/client/ayon_max/plugins/load/load_tycache.py
+++ b/client/ayon_max/plugins/load/load_tycache.py
@@ -10,7 +10,7 @@ from ayon_max.api.pipeline import (
     update_custom_attribute_data,
     remove_container_data
 )
-from ayon_core.pipeline import get_representation_path, load
+from ayon_core.pipeline import load
 
 
 class TyCacheLoader(load.LoaderPlugin):
@@ -44,7 +44,7 @@ class TyCacheLoader(load.LoaderPlugin):
         from pymxs import runtime as rt
 
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node = rt.GetNodeByName(container["instance_node"])
         node_list = get_previous_loaded_object(node)
         update_custom_attribute_data(node, node_list)

--- a/client/ayon_max/plugins/load/load_tycache.py
+++ b/client/ayon_max/plugins/load/load_tycache.py
@@ -51,8 +51,10 @@ class TyCacheLoader(load.LoaderPlugin):
         with maintained_selection():
             for tyc in node_list:
                 tyc.filename = path
+
         lib.imprint(container["instance_node"], {
-            "representation": repre_entity["id"]
+            "representation": repre_entity["id"],
+            "project_name": context["project"]["name"]
         })
 
     def switch(self, container, context):


### PR DESCRIPTION
## Changelog Description
This PR is to add the `context["project"]["name"]` as part of the container data for loading and updating assets

## Additional review information
Please test along with this PR https://github.com/ynput/ayon-core/pull/1005

## Testing notes:
1. Launch Max
2. Load assets across different library projects
