### PR TITLE
Avoid glitching viewport

### DIFF
--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -352,6 +352,7 @@ def set_context_setting():
     reset_frame_range()
     reset_colorspace()
     reset_unit_scale()
+    rt.viewport.ResetAllViews()
 
 
 def get_max_version():


### PR DESCRIPTION
## Changelog Description
Quick fix on the glitching viewport after setting project folder with this merge of the PR https://github.com/ynput/ayon-3dsmax/pull/22
In the latest develop branch of Max, the viewport would be messed up with loading object.

https://github.com/user-attachments/assets/e67e7617-b861-4264-8dbc-c8c12e027025


## Additional review information
n/a

## Testing notes:
1. Launch 3dsmax
2. The viewport won't be glitching like the video shown anymore.
