### PR TITLE
Implementation of publishing/loading assets with tyCache Modifier

### DIFF
--- a/client/ayon_max/plugins/load/load_tycache.py
+++ b/client/ayon_max/plugins/load/load_tycache.py
@@ -1,4 +1,5 @@
 import os
+from pymxs import runtime as rt
 from ayon_max.api import lib, maintained_selection
 from ayon_max.api.lib import (
     unique_namespace,
@@ -10,7 +11,8 @@ from ayon_max.api.pipeline import (
     update_custom_attribute_data,
     remove_container_data
 )
-from ayon_core.pipeline import get_representation_path, load
+from ayon_core.pipeline import load
+from ayon_core.lib import BoolDef
 
 
 class TyCacheLoader(load.LoaderPlugin):
@@ -22,18 +24,31 @@ class TyCacheLoader(load.LoaderPlugin):
     icon = "code-fork"
     color = "green"
 
+    @classmethod
+    def get_options(cls, contexts):
+        defs = []
+        if (
+            str(cls.__class__.__name__) == "TyCacheLoader"
+            and int(rt.tyFlow_version()) >= 112000
+        ):
+            defs.append(
+                BoolDef(
+                    "use_tycache_modifier",
+                    label="Load tycache with modifier",
+                    default=False
+                )
+            )
+        return defs
+
     def load(self, context, name=None, namespace=None, data=None):
         """Load tyCache"""
-        from pymxs import runtime as rt
         filepath = os.path.normpath(self.filepath_from_context(context))
-        obj = rt.tyCache()
-        obj.filename = filepath
 
         namespace = unique_namespace(
             name + "_",
             suffix="_",
         )
-        obj.name = f"{namespace}:{obj.name}"
+        obj = self.load_tycache(filepath, namespace)
 
         return containerise(
             name, [obj], context,
@@ -41,16 +56,13 @@ class TyCacheLoader(load.LoaderPlugin):
 
     def update(self, container, context):
         """update the container"""
-        from pymxs import runtime as rt
-
         repre_entity = context["representation"]
-        path = get_representation_path(repre_entity)
+        path = os.path.normpath(self.filepath_from_context(context))
         node = rt.GetNodeByName(container["instance_node"])
         node_list = get_previous_loaded_object(node)
         update_custom_attribute_data(node, node_list)
         with maintained_selection():
-            for tyc in node_list:
-                tyc.filename = path
+            self.load_tycache(path, node_list)
         lib.imprint(container["instance_node"], {
             "representation": repre_entity["id"]
         })
@@ -60,11 +72,19 @@ class TyCacheLoader(load.LoaderPlugin):
 
     def remove(self, container):
         """remove the container"""
-        from pymxs import runtime as rt
         node = rt.GetNodeByName(container["instance_node"])
         remove_container_data(node)
         rt.Delete(node)
 
+    def load_tycache(self, filepath, namespace):
+        obj = rt.tyCache()
+        obj.filename = filepath
+        obj.name = f"{namespace}:{obj.name}"
+        return obj
+
+    def update_tycache(self, path, node_list):
+        for tyc in node_list:
+            tyc.filename = path
 
 class TySplineCacheLoader(TyCacheLoader):
     """TyCache(Spline) Loader."""
@@ -75,19 +95,36 @@ class TySplineCacheLoader(TyCacheLoader):
     icon = "code-fork"
     color = "green"
 
-    def load(self, context, name=None, namespace=None, data=None):
-        from pymxs import runtime as rt
-        filepath = os.path.normpath(self.filepath_from_context(context))
+    def load_tycache(self, filepath, namespace):
         obj = rt.tyCache()
         obj.filename = filepath
         tySplineCache_modifier = rt.tySplineCache()
         rt.addModifier(obj, tySplineCache_modifier)
-        namespace = unique_namespace(
-            name + "_",
-            suffix="_",
-        )
         obj.name = f"{namespace}:{obj.name}"
+        return obj
 
-        return containerise(
-            name, [obj], context,
-            namespace, loader=self.__class__.__name__)
+
+class TyCacheModifierLoader(TyCacheLoader):
+    """Load TyCache with tyCache Modifier """
+
+    representations = {"tycm"}
+    order = -8
+    icon = "code-fork"
+    color = "green"
+
+    def load_tycache(self, filepath, namespace):
+        obj = rt.Container()
+        tyc_modifier = rt.tyCachemodifier()
+        # switch the tyCache modifier mode
+        # to load/save the cache in tyc format
+        tyc_modifier.mode = 1
+        tyc_modifier.filename = filepath
+        rt.addModifier(obj, tyc_modifier)
+        obj.name = f"{namespace}:{tyc_modifier.name}"
+        return obj
+
+    def update_tycache(self, path, node_list):
+        for node in node_list:
+            for modifier in node.modifiers:
+                if rt.Classof(modifier) == "tyCachemodifier":
+                    modifier.filename = path

--- a/client/ayon_max/plugins/load/load_tycache.py
+++ b/client/ayon_max/plugins/load/load_tycache.py
@@ -11,8 +11,7 @@ from ayon_max.api.pipeline import (
     update_custom_attribute_data,
     remove_container_data
 )
-from ayon_core.pipeline import load
-from ayon_core.lib import BoolDef
+from ayon_core.pipeline import load, LoadError
 
 
 class TyCacheLoader(load.LoaderPlugin):
@@ -23,22 +22,6 @@ class TyCacheLoader(load.LoaderPlugin):
     order = -8
     icon = "code-fork"
     color = "green"
-
-    @classmethod
-    def get_options(cls, contexts):
-        defs = []
-        if (
-            str(cls.__class__.__name__) == "TyCacheLoader"
-            and int(rt.tyFlow_version()) >= 112000
-        ):
-            defs.append(
-                BoolDef(
-                    "use_tycache_modifier",
-                    label="Load tycache with modifier",
-                    default=False
-                )
-            )
-        return defs
 
     def load(self, context, name=None, namespace=None, data=None):
         """Load tyCache"""
@@ -113,6 +96,10 @@ class TyCacheModifierLoader(TyCacheLoader):
     color = "green"
 
     def load_tycache(self, filepath, namespace):
+        if int(rt.tyFlow_version()) < 112000:
+            raise LoadError(
+                "This loader only works in TyFlow v1.12. "
+                "Please update your TyFlow! ")
         obj = rt.Container()
         tyc_modifier = rt.tyCachemodifier()
         # switch the tyCache modifier mode

--- a/client/ayon_max/plugins/load/load_tycache.py
+++ b/client/ayon_max/plugins/load/load_tycache.py
@@ -91,6 +91,7 @@ class TyCacheModifierLoader(TyCacheLoader):
     """Load TyCache with tyCache Modifier """
 
     representations = {"tycm"}
+    label = "Load TyCache with Modifier"
     order = -8
     icon = "code-fork"
     color = "green"


### PR DESCRIPTION
## Changelog Description
This PR is to add feature of publishing and loading assets with tyCache Modifier in tycm format
- [ ] Loader
- [ ] Publisher

## Additional review information
For tech guys info: Differ from the existing tyFlow product type, it would inherit from the general MaxCreator plugin

## Testing notes:
Load
1. Load ` load tyCache with TyCache Modifier`
2. Should be loading the empty container with the tyCache modifier which stores the loaded caches.
Publish
1. Create TyCache(Modifier)
2. Publish