### PR TITLE
Reset Unit Scale default to False in ayon setting and Popup menu before the reset

### DIFF
--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -315,6 +315,11 @@ def reset_unit_scale():
         log.info("Using default scale display type.")
         rt.units.DisplayType = rt.Name("Generic")
         return
+    scene_scale = settings["unit_scale_settings"]["scene_unit_scale"]
+    if rt.units.DisplayType == rt.Name("Metric") and (
+        rt.units.MetricType == rt.Name(scene_scale)
+    ):
+        return
 
     parent = get_main_window()
     if not is_headless():

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -316,15 +316,15 @@ def reset_unit_scale():
 
 
     class ResetUnitScaleWindow(QtWidgets.QDialog):
-        def __init__(self, parent=None, scene_scale=None):
-            super(ResetUnitScaleWindow, self).__init__(parent=parent, scene_scale=None)
+        def __init__(self, parent=None):
+            super(ResetUnitScaleWindow, self).__init__(parent=parent)
             self.setWindowFlags(self.windowFlags() | QtCore.Qt.FramelessWindowHint)
             self.setWindowTitle("Reset Unit Scale")
 
             layout = QtWidgets.QVBoxLayout()
             layout.setContentsMargins(10, 5, 10, 10)
             message_label = QtWidgets.QLabel(
-                f"Are you sure you want to reset Unit Scale to '{scene_scale}'?"
+                f"Are you sure you want to reset Unit Scale?"
             )
 
             self.ok_button = QtWidgets.QPushButton("Ok", self)
@@ -349,8 +349,7 @@ def reset_unit_scale():
             self.close()
 
     if scene_scale:
-        dialog = ResetUnitScaleWindow(
-            parent=parent, scene_scale=scene_scale)
+        dialog = ResetUnitScaleWindow(parent=parent)
         dialog.setStyleSheet(load_stylesheet())
         dialog.show()
 

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -330,7 +330,8 @@ def reset_unit_scale(popup=False):
             layout = QtWidgets.QVBoxLayout()
             layout.setContentsMargins(10, 5, 10, 10)
             message_label = QtWidgets.QLabel(
-                f"Are you sure you want to reset Unit Scale to '{scene_scale}'?"
+                "Scene units do not match studio/project preferences."
+                f" Would you like to set your scene unit scale to '{scene_scale}'?"
             )
 
             self.ok_button = QtWidgets.QPushButton("Ok", self)
@@ -398,6 +399,7 @@ def set_context_setting():
     """
     reset_scene_resolution()
     reset_frame_range()
+    reset_unit_scale()
     reset_colorspace()
     rt.viewport.ResetAllViews()
 

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -324,7 +324,7 @@ def reset_unit_scale():
             layout = QtWidgets.QVBoxLayout()
             layout.setContentsMargins(10, 5, 10, 10)
             message_label = QtWidgets.QLabel(
-                f"Are you sure you want to reset Unit Scale {scene_scale}?"
+                f"Are you sure you want to reset Unit Scale to '{scene_scale}'?"
             )
 
             self.ok_button = QtWidgets.QPushButton("Ok", self)

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -324,7 +324,7 @@ def reset_unit_scale():
             layout = QtWidgets.QVBoxLayout()
             layout.setContentsMargins(10, 5, 10, 10)
             message_label = QtWidgets.QLabel(
-                f"Are you sure you want to reset Unit Scale?"
+                f"Are you sure you want to reset Unit Scale {scene_scale}?"
             )
 
             self.ok_button = QtWidgets.QPushButton("Ok", self)

--- a/client/ayon_max/api/menu.py
+++ b/client/ayon_max/api/menu.py
@@ -164,4 +164,4 @@ class AYONMenu(object):
 
     def unit_scale_callback(self):
         """Callback to reset unit scale"""
-        return lib.reset_unit_scale(popup=True)
+        return lib.reset_unit_scale()

--- a/client/ayon_max/api/menu.py
+++ b/client/ayon_max/api/menu.py
@@ -164,4 +164,4 @@ class AYONMenu(object):
 
     def unit_scale_callback(self):
         """Callback to reset unit scale"""
-        return lib.reset_unit_scale()
+        return lib.reset_unit_scale(popup=True)

--- a/client/ayon_max/api/menu.py
+++ b/client/ayon_max/api/menu.py
@@ -164,4 +164,4 @@ class AYONMenu(object):
 
     def unit_scale_callback(self):
         """Callback to reset unit scale"""
-        return lib.reset_unit_scale()
+        return lib.validate_unit_scale()

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -240,6 +240,7 @@ def on_before_open():
     """Check and set up project before opening workfile
     """
     _set_project()
+    lib.reset_unit_scale()
 
 
 def load_custom_attribute_data():

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -246,7 +246,7 @@ def on_before_open():
 def on_after_open():
     """Check and set up unit scale after opening workfile if user enabled.
     """
-    lib.reset_unit_scale()
+    lib.validate_unit_scale()
 
 
 def load_custom_attribute_data():

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -57,6 +57,7 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         self.menu = AYONMenu()
 
         register_event_callback("workfile.open.before", on_before_open)
+        register_event_callback("workfile.open.after", on_after_open)
         self._has_been_setup = True
         rt.callbacks.addScript(rt.Name('systemPostNew'), on_new)
 
@@ -240,6 +241,11 @@ def on_before_open():
     """Check and set up project before opening workfile
     """
     _set_project()
+
+
+def on_after_open():
+    """Check and set up unit scale after opening workfile if user enabled.
+    """
     lib.reset_unit_scale()
 
 

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -109,7 +109,7 @@ DEFAULT_MXP_WORKSPACE_SETTINGS = "\n".join((
 
 DEFAULT_VALUES = {
     "unit_scale_settings": {
-        "enabled": True,
+        "enabled": False,
         "scene_unit_scale": "Centimeters"
     },
     "mxp_workspace": {


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-3dsmax/issues/30
This PR is to set the reset unit scale default value to False and also add popup window to alter user for the change of the unit scale.

## Additional review information
n/a

## Testing notes:
1. Install and Build 3dsmax addon
2. Check `ayon+settings://max/unit_scale_settings`
3. It should be False
4. Enable it
5. Launch Max
6. There would be popup menu to ask you if you want to reset unit scale.
