### PR TITLE
Remove avalon instance id

### DIFF
--- a/client/ayon_max/api/plugin.py
+++ b/client/ayon_max/api/plugin.py
@@ -10,8 +10,7 @@ from ayon_core.pipeline import (
     CreatedInstance,
     Creator,
     CreatorError,
-    AYON_INSTANCE_ID,
-    AVALON_INSTANCE_ID,
+    AYON_INSTANCE_ID
 )
 
 from .lib import imprint, lsattr, read, get_tyflow_export_operators
@@ -274,7 +273,7 @@ class MaxCreatorBase(object):
         shared_data["max_cached_instances"] = {}
 
         cached_instances = []
-        for id_type in [AYON_INSTANCE_ID, AVALON_INSTANCE_ID]:
+        for id_type in [AYON_INSTANCE_ID]:
             cached_instances.extend(lsattr("id", id_type))
 
         for i in cached_instances:


### PR DESCRIPTION
## Changelog Description
This PR is to remove deprecated `AVALON_INSTANCE_ID` in regard to https://github.com/ynput/ayon-core/pull/1105

## Additional review information
Tested with https://github.com/ynput/ayon-core/pull/1105

## Testing notes:
1. Launch Max
2. Create some instance
3. Publish successfully
