### PR TITLE
Make sure project creation performed correctly when it enabled in ayon setting 

### DIFF
--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -383,7 +383,6 @@ def set_context_setting():
     reset_frame_range()
     validate_unit_scale()
     reset_colorspace()
-    rt.viewport.ResetAllViews()
 
 
 def get_max_version():

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -216,16 +216,17 @@ def containerise(name: str, nodes: list, context,
 def _set_project():
     project_name = get_current_project_name()
     project_settings = get_project_settings(project_name)
-    workdir = os.getenv("AYON_WORKDIR")
-    os.makedirs(workdir, exist_ok=True)
-    rt.pathConfig.setCurrentProjectFolder(workdir)
     enable_project_creation = project_settings["max"].get("enabled_project_creation")
-    if enable_project_creation:
+    if not enable_project_creation:
         directory_count = rt.pathConfig.getProjectSubDirectoryCount()
         autobackup_dir = rt.pathConfig.GetDir(rt.Name("autoback"))
         os.makedirs(autobackup_dir, exist_ok=True)
         log.debug("Project creation disabled. Skipping project creation.")
         return
+
+    workdir = os.getenv("AYON_WORKDIR")
+    os.makedirs(workdir, exist_ok=True)
+    rt.pathConfig.setCurrentProjectFolder(workdir)
 
     mxp_filepath = os.path.join(workdir, "workspace.mxp")
     if os.path.exists(mxp_filepath):

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -236,7 +236,7 @@ def _set_project():
                 os.makedirs(proj_dir, exist_ok=True)
 
     # avoid glitching viewport
-    # rt.viewport.ResetAllViews()
+    rt.viewport.ResetAllViews()
 
 
 def _set_autobackup_dir():

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -238,6 +238,8 @@ def _set_project():
             if proj_dir:
                 os.makedirs(proj_dir, exist_ok=True)
 
+    rt.viewport.ResetAllViews()
+
 
 def on_before_open():
     """Check and set up project before opening workfile

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -214,13 +214,14 @@ def containerise(name: str, nodes: list, context,
 
 
 def _set_project():
+    # set up autobackup folder to avoid non-existing filepath
+    directory_count = rt.pathConfig.getProjectSubDirectoryCount()
+    autobackup_dir = rt.pathConfig.GetDir(rt.Name("autoback"))
+    os.makedirs(autobackup_dir, exist_ok=True)
     project_name = get_current_project_name()
     project_settings = get_project_settings(project_name)
     enable_project_creation = project_settings["max"].get("enabled_project_creation")
     if not enable_project_creation:
-        directory_count = rt.pathConfig.getProjectSubDirectoryCount()
-        autobackup_dir = rt.pathConfig.GetDir(rt.Name("autoback"))
-        os.makedirs(autobackup_dir, exist_ok=True)
         log.debug("Project creation disabled. Skipping project creation.")
         return
 

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -52,6 +52,7 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_creator_plugin_path(CREATE_PATH)
 
         _set_project()
+        _set_autobackup_dir()
         lib.set_context_setting()
 
         self.menu = AYONMenu()
@@ -214,10 +215,6 @@ def containerise(name: str, nodes: list, context,
 
 
 def _set_project():
-    # set up autobackup folder to avoid non-existing filepath
-    directory_count = rt.pathConfig.getProjectSubDirectoryCount()
-    autobackup_dir = rt.pathConfig.GetDir(rt.Name("autoback"))
-    os.makedirs(autobackup_dir, exist_ok=True)
     project_name = get_current_project_name()
     project_settings = get_project_settings(project_name)
     enable_project_creation = project_settings["max"].get("enabled_project_creation")
@@ -238,7 +235,15 @@ def _set_project():
             if proj_dir:
                 os.makedirs(proj_dir, exist_ok=True)
 
-    rt.viewport.ResetAllViews()
+    # avoid glitching viewport
+    # rt.viewport.ResetAllViews()
+
+
+def _set_autobackup_dir():
+    """Set up autobackup folder to avoid non-existing directory
+    """
+    autobackup_dir = rt.pathConfig.GetDir(rt.Name("autoback"))
+    os.makedirs(autobackup_dir, exist_ok=True)
 
 
 def on_before_open():


### PR DESCRIPTION
## Changelog Description
Implement the correct logic of project creation as followed
1. Project should be created and autobackup directory should be existed when project creation enabled
2. Reset All Scene Review should only happened when project creation enabled

## Additional review information
n/a

## Testing notes:
1. Try to enable or not enable the project creation `ayon+settings://max/mxp_workspace/enabled_project_creation`
3. Launch Max
4. Check your workdir to see if all files are created
5. Check if your autobackup directories have been created.
