### PR TITLE
Implementation of vdb loader for vdbcache product

### DIFF
--- a/client/ayon_max/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_max/plugins/load/load_redshift_proxy.py
@@ -1,5 +1,4 @@
 import os
-import clique
 
 from ayon_core.pipeline import load
 from ayon_core.pipeline.load import LoadError

--- a/client/ayon_max/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_max/plugins/load/load_redshift_proxy.py
@@ -32,7 +32,7 @@ class RedshiftProxyLoader(load.LoaderPlugin):
         if "redshift4max.dlr" not in plugin_info:
             raise LoadError("Redshift not loaded/installed in Max..")
         filepath = self.filepath_from_context(context)
-        rs_obj = self._create_redshift_object_type()
+        rs_obj = self._get_redshift_object_type()
         rs_obj.file = filepath
 
         namespace = unique_namespace(
@@ -68,7 +68,7 @@ class RedshiftProxyLoader(load.LoaderPlugin):
         node = rt.GetNodeByName(container["instance_node"])
         remove_container_data(node)
 
-    def _create_redshift_object_type(self):
+    def _get_redshift_object_type(self):
         return rt.RedshiftProxy()
 
 
@@ -82,5 +82,5 @@ class RedshiftVolumeLoader(RedshiftProxyLoader):
     icon = "code-fork"
     color = "orange"
 
-    def _create_redshift_object_type(self):
+    def _get_redshift_object_type(self):
         return rt.RedshiftVolumeGrid()


### PR DESCRIPTION
## Changelog Description
Implementation of vdb loader for vdbcache product in 3dsmax. The user can load vdb from Houdini in 3dsmax by using this loader

## Additional review information
- As this loader inherited from redshiftproxy loader, please also test with proxy loading to ensure everything works.
- You need to have redshift for 3dsmax before loading vdb/proxy

## Testing notes:
1. Launch Max
2. Load Proxy/VDB
