### PR TITLE
Set the context setting only for project when launching without last workfile

### DIFF
--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -53,7 +53,9 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         _set_project()
         _set_autobackup_dir()
-        lib.set_context_setting()
+
+        if os.environ["AVALON_OPEN_LAST_WORKFILE"] == "0":
+            lib.set_context_setting()
 
         self.menu = AYONMenu()
 

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -62,7 +62,6 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_event_callback("workfile.open.before", on_before_open)
         register_event_callback("workfile.open.after", on_after_open)
         self._has_been_setup = True
-        rt.callbacks.addScript(rt.Name('systemPostNew'), on_new)
 
         rt.callbacks.addScript(rt.Name('filePostOpen'),
                                lib.check_colorspace)
@@ -187,14 +186,6 @@ def ls():
 
     for container in sorted(containers, key=attrgetter("name")):
         yield parse_container(container)
-
-
-def on_new():
-    lib.set_context_setting()
-    if rt.checkForSave():
-        rt.resetMaxFile(rt.Name("noPrompt"))
-        rt.clearUndoBuffer()
-        rt.redrawViews()
 
 
 def containerise(name: str, nodes: list, context,

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -54,7 +54,7 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         _set_project()
         _set_autobackup_dir()
 
-        if os.environ["AVALON_OPEN_LAST_WORKFILE"] == "0":
+        if os.getenv("AVALON_OPEN_LAST_WORKFILE") != "1":
             lib.set_context_setting()
 
         self.menu = AYONMenu()
@@ -62,6 +62,7 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_event_callback("workfile.open.before", on_before_open)
         register_event_callback("workfile.open.after", on_after_open)
         self._has_been_setup = True
+        rt.callbacks.addScript(rt.Name('systemPostNew'), on_new)
 
         rt.callbacks.addScript(rt.Name('filePostOpen'),
                                lib.check_colorspace)
@@ -186,6 +187,14 @@ def ls():
 
     for container in sorted(containers, key=attrgetter("name")):
         yield parse_container(container)
+
+
+def on_new():
+    lib.set_context_setting()
+    if rt.checkForSave():
+        rt.resetMaxFile(rt.Name("noPrompt"))
+        rt.clearUndoBuffer()
+        rt.redrawViews()
 
 
 def containerise(name: str, nodes: list, context,

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -191,8 +191,10 @@ def ls():
 
 
 def on_new():
-    if os.getenv("AVALON_OPEN_LAST_WORKFILE") != "1":
-        lib.set_context_setting()
+    last_workfile = os.getenv("AYON_LAST_WORKFILE")
+    if os.getenv("AVALON_OPEN_LAST_WORKFILE") != "1"  \
+        or not os.path.exists(last_workfile):
+            lib.set_context_setting()
 
 
 def containerise(name: str, nodes: list, context,

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -54,23 +54,13 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         _set_project()
         _set_autobackup_dir()
 
-        if os.getenv("AVALON_OPEN_LAST_WORKFILE") != "1":
-            lib.set_context_setting()
-
         self.menu = AYONMenu()
 
         register_event_callback("workfile.open.before", on_before_open)
         register_event_callback("workfile.open.after", on_after_open)
         self._has_been_setup = True
-        rt.callbacks.addScript(rt.Name('systemPostNew'), on_new)
+        self._register_callbacks()
 
-        rt.callbacks.addScript(rt.Name('filePostOpen'),
-                               lib.check_colorspace)
-
-        rt.callbacks.addScript(rt.Name('postWorkspaceChange'),
-                               self._deferred_menu_creation)
-        rt.NodeEventCallback(
-            nameChanged=lib.update_modifier_node_names)
 
     def workfile_has_unsaved_changes(self):
         return rt.getSaveRequired()
@@ -94,11 +84,22 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return ls()
 
     def _register_callbacks(self):
-        rt.callbacks.removeScripts(id=rt.name("OpenPypeCallbacks"))
-
+        rt.callbacks.removeScripts(id=rt.name("AyonCallbacks"))
         rt.callbacks.addScript(
-            rt.Name("postLoadingMenus"),
-            self._deferred_menu_creation, id=rt.Name('OpenPypeCallbacks'))
+            rt.Name('welcomeScreenDone'),
+            on_new, id=rt.name("AyonCallbacks")
+        )
+        rt.callbacks.addScript(
+            rt.Name('systemPostNew'),
+            lib.set_context_setting,
+            id=rt.name("AyonCallbacks")
+        )
+        rt.callbacks.addScript(
+            rt.Name('postWorkspaceChange'),
+            self._deferred_menu_creation,
+            id=rt.name("AyonCallbacks"))
+        rt.NodeEventCallback(
+            nameChanged=lib.update_modifier_node_names)
 
     def _deferred_menu_creation(self):
         self.log.info("Building menu ...")
@@ -190,11 +191,8 @@ def ls():
 
 
 def on_new():
-    lib.set_context_setting()
-    if rt.checkForSave():
-        rt.resetMaxFile(rt.Name("noPrompt"))
-        rt.clearUndoBuffer()
-        rt.redrawViews()
+    if os.getenv("AVALON_OPEN_LAST_WORKFILE") != "1":
+        lib.set_context_setting()
 
 
 def containerise(name: str, nodes: list, context,


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the context setting set only when launching without last workfile.
Fix https://github.com/ynput/ayon-3dsmax/issues/39

## Additional review information
n/a

## Testing notes:
1. Launch with/without last workfile
2. Launch with last workfile would mean no context setting made in the existing scene, you only notice that when launching without last workfile.
3. Create new scene
4. Conext setting should be set too.
