### PR TITLE
Align resolution data with other hosts in Ayon

### DIFF
--- a/client/ayon_max/plugins/publish/collect_review.py
+++ b/client/ayon_max/plugins/publish/collect_review.py
@@ -55,8 +55,8 @@ class CollectReview(pyblish.api.InstancePlugin,
             "imageFormat": creator_attrs["imageFormat"],
             "keepImages": creator_attrs["keepImages"],
             "fps": instance.context.data["fps"],
-            "review_width": creator_attrs["review_width"],
-            "review_height": creator_attrs["review_height"],
+            "resolutionWidth": creator_attrs["review_width"],
+            "resolutionHeight": creator_attrs["review_height"],
         }
 
         if int(get_max_version()) >= 2024:

--- a/client/ayon_max/plugins/publish/extract_review_animation.py
+++ b/client/ayon_max/plugins/publish/extract_review_animation.py
@@ -34,8 +34,8 @@ class ExtractReviewAnimation(publish.Extractor):
             start,
             end,
             percentSize=instance.data["percentSize"],
-            width=instance.data["review_width"],
-            height=instance.data["review_height"],
+            width=instance.data["resolutionWidth"],
+            height=instance.data["resolutionHeight"],
             viewport_options=viewport_options)
 
         filenames = [os.path.basename(path) for path in files]

--- a/client/ayon_max/plugins/publish/extract_thumbnail.py
+++ b/client/ayon_max/plugins/publish/extract_thumbnail.py
@@ -30,8 +30,8 @@ class ExtractThumbnail(publish.Extractor):
             start_frame=frame,
             end_frame=frame,
             percentSize=instance.data["percentSize"],
-            width=instance.data["review_width"],
-            height=instance.data["review_height"],
+            width=instance.data["resolutionWidth"],
+            height=instance.data["resolutionHeight"],
             viewport_options=viewport_options)
 
         thumbnail = next(os.path.basename(path) for path in files)

--- a/client/ayon_max/plugins/publish/validate_resolution_setting.py
+++ b/client/ayon_max/plugins/publish/validate_resolution_setting.py
@@ -72,8 +72,8 @@ class ValidateReviewResolutionSetting(ValidateResolutionSetting):
     actions = [RepairAction]
 
     def get_current_resolution(self, instance):
-        current_width = instance.data["review_width"]
-        current_height = instance.data["review_height"]
+        current_width = instance.data["resolutionWidth"]
+        current_height = instance.data["resolutionHeight"]
         return current_width, current_height
 
     @classmethod


### PR DESCRIPTION
## Changelog Description
This PR is to add resolution data into instance data to align with the resolution data in other hosts.
Instead of `review_height` and `review_width`, we would use `resolutionHeight` and `resolutionWidth` instead.
Links to https://github.com/ynput/ayon-core/pull/1234

## Additional review information
Try along with the linked PR above and this PR would ensure publishing review in Max would not error out `Extract Review` when handling missing frame set to `generate blank frame`(related setting: `ayon+settings://core/publish/ExtractReview/profiles/0/outputs/1/fill_missing_frames`).

## Testing notes:
1. Create Review in Max
2. Publish
