### PR TITLE
 Support to setting up the multipass during creating render instance

### DIFF
--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -8,7 +8,8 @@ from ayon_core.pipeline.context_tools import get_current_folder_entity
 from ayon_max.api.lib import (
     set_render_frame_range,
     get_current_renderer,
-    get_default_render_folder
+    get_default_render_folder,
+    get_multipass_setting,
 )
 
 
@@ -99,6 +100,11 @@ class RenderSettings(object):
             "Quicksilver_Hardware_Renderer",
         ]:
             self.render_element_layer(output, width, height, img_fmt)
+
+        multipass_enabled = get_multipass_setting(setting)
+        # TODO: supports multipass for different renderers
+        if renderer == "Redshift_Renderer":
+            rt.renderers.current.separateAovFiles = multipass_enabled
 
         rt.rendSaveFile = True
 

--- a/client/ayon_max/plugins/load/load_max_scene.py
+++ b/client/ayon_max/plugins/load/load_max_scene.py
@@ -89,6 +89,7 @@ class MaxSceneLoader(load.LoaderPlugin):
         "useSceneMtlDups": "Use Scene Material",
         "renameMtlDups": "Merge and Rename Incoming Material"
         }
+
     @classmethod
     def get_options(cls, contexts):
         return [


### PR DESCRIPTION
## Changelog Description
This PR is to support to set up the multipass when creating render instance

## Additional review information
- The multipass option currently only works for Redshift Renderer
- Test with manually turning on/off the seperate AOV files and publish after creating instances

## Testing notes:
1. Create Render Instance with/without multipass by toggling `ayon+settings://max/RenderSettings/multipass`
2. Publish
