### PR TITLE
Make sure render setting updated after repairing with validate renderpass

### DIFF
--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -69,11 +69,9 @@ class RenderProducts(object):
 
             if renderer in [
                 "ART_Renderer",
-                "V_Ray_6_Hotfix_3",
-                "V_Ray_GPU_6_Hotfix_3",
                 "Default_Scanline_Renderer",
                 "Quicksilver_Hardware_Renderer",
-            ]:
+            ] or renderer.startswith("V_Ray"):
                 render_name = self.get_render_elements_name()
                 if render_name:
                     for name in render_name:
@@ -112,10 +110,7 @@ class RenderProducts(object):
                                 filename, name, start_frame,
                                 end_frame, ext)
                         })
-            elif renderer in [
-                "V_Ray_6_Hotfix_3",
-                "V_Ray_GPU_6_Hotfix_3"
-            ]:
+            elif renderer.startswith("V_Ray"):
                 if ext != "exr":
                     render_name = self.get_render_elements_name()
                     if render_name:
@@ -145,11 +140,9 @@ class RenderProducts(object):
 
         if renderer in [
             "ART_Renderer",
-            "V_Ray_6_Hotfix_3",
-            "V_Ray_GPU_6_Hotfix_3",
             "Default_Scanline_Renderer",
             "Quicksilver_Hardware_Renderer",
-        ]:
+        ] or renderer.startswith("V_Ray"):
             render_name = self.get_render_elements_name()
             if render_name:
                 for name in render_name:
@@ -189,10 +182,7 @@ class RenderProducts(object):
                             output_file, name, start_frame,
                             end_frame, img_fmt)
                     })
-        elif renderer in [
-            "V_Ray_6_Hotfix_3",
-            "V_Ray_GPU_6_Hotfix_3"
-        ]:
+        elif renderer.startswith("V_Ray"):
             if img_fmt != "exr":
                 render_name = self.get_render_elements_name()
                 if render_name:

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -71,7 +71,7 @@ class RenderProducts(object):
                 "ART_Renderer",
                 "Default_Scanline_Renderer",
                 "Quicksilver_Hardware_Renderer",
-            ] or renderer.startswith("V_Ray_"):
+            ]:
                 render_name = self.get_render_elements_name()
                 if render_name:
                     for name in render_name:

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -71,7 +71,7 @@ class RenderProducts(object):
                 "ART_Renderer",
                 "Default_Scanline_Renderer",
                 "Quicksilver_Hardware_Renderer",
-            ] or renderer.startswith("V_Ray"):
+            ] or renderer.startswith("V_Ray_"):
                 render_name = self.get_render_elements_name()
                 if render_name:
                     for name in render_name:
@@ -110,7 +110,7 @@ class RenderProducts(object):
                                 filename, name, start_frame,
                                 end_frame, ext)
                         })
-            elif renderer.startswith("V_Ray"):
+            elif renderer.startswith("V_Ray_"):
                 if ext != "exr":
                     render_name = self.get_render_elements_name()
                     if render_name:
@@ -142,7 +142,7 @@ class RenderProducts(object):
             "ART_Renderer",
             "Default_Scanline_Renderer",
             "Quicksilver_Hardware_Renderer",
-        ] or renderer.startswith("V_Ray"):
+        ] or renderer.startswith("V_Ray_"):
             render_name = self.get_render_elements_name()
             if render_name:
                 for name in render_name:
@@ -182,7 +182,7 @@ class RenderProducts(object):
                             output_file, name, start_frame,
                             end_frame, img_fmt)
                     })
-        elif renderer.startswith("V_Ray"):
+        elif renderer.startswith("V_Ray_"):
             if img_fmt != "exr":
                 render_name = self.get_render_elements_name()
                 if render_name:

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -142,7 +142,7 @@ class RenderProducts(object):
             "ART_Renderer",
             "Default_Scanline_Renderer",
             "Quicksilver_Hardware_Renderer",
-        ] or renderer.startswith("V_Ray_"):
+        ]:
             render_name = self.get_render_elements_name()
             if render_name:
                 for name in render_name:

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -71,7 +71,7 @@ class RenderProducts(object):
                 "ART_Renderer",
                 "Default_Scanline_Renderer",
                 "Quicksilver_Hardware_Renderer",
-            ]:
+            ] and renderer.startswith("V_Ray_"):
                 render_name = self.get_render_elements_name()
                 if render_name:
                     for name in render_name:
@@ -110,16 +110,6 @@ class RenderProducts(object):
                                 filename, name, start_frame,
                                 end_frame, ext)
                         })
-            elif renderer.startswith("V_Ray_"):
-                if ext != "exr":
-                    render_name = self.get_render_elements_name()
-                    if render_name:
-                        for name in render_name:
-                            aovs_frames.update({
-                                f"{camera}_{name}": self.get_expected_aovs(
-                                    filename, name, start_frame,
-                                    end_frame, ext)
-                            })
 
         return aovs_frames
 
@@ -142,7 +132,7 @@ class RenderProducts(object):
             "ART_Renderer",
             "Default_Scanline_Renderer",
             "Quicksilver_Hardware_Renderer",
-        ]:
+        ] and renderer.startswith("V_Ray_"):
             render_name = self.get_render_elements_name()
             if render_name:
                 for name in render_name:
@@ -182,16 +172,6 @@ class RenderProducts(object):
                             output_file, name, start_frame,
                             end_frame, img_fmt)
                     })
-        elif renderer.startswith("V_Ray_"):
-            if img_fmt != "exr":
-                render_name = self.get_render_elements_name()
-                if render_name:
-                    for name in render_name:
-                        render_dict.update({
-                            name: self.get_expected_aovs(
-                                output_file, name, start_frame,
-                                end_frame, img_fmt)      # noqa
-                        })
 
         return render_dict
 

--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -12,6 +12,26 @@ from ayon_max.api.lib import (
 )
 
 
+# Note that V-Ray is handled as a special case
+# in the `is_supported_renderer` function
+SUPPORTED_RENDERERS = {
+    "ART_Renderer",
+    "Redshift_Renderer",
+    "Default_Scanline_Renderer",
+    "Quicksilver_Hardware_Renderer",
+}
+
+def is_supported_renderer(renderer_name: str) -> bool:
+    if renderer_name in SUPPORTED_RENDERERS:
+        return True
+    if renderer_name.startswith("V_Ray_"):
+        # V-Ray renderer name keeps changing, like
+        # 'V_Ray_6_Hotfix_3' and 'V_Ray_GPU_6_Hotfix_3'
+        # so we consider all V-Ray releases supported
+        return True
+    return False
+
+
 class RenderSettings(object):
 
     log = Logger.get_logger("RenderSettings")
@@ -90,12 +110,7 @@ class RenderSettings(object):
         if renderer == "Arnold":
             self.arnold_setup()
 
-        if renderer in [
-            "ART_Renderer",
-            "Redshift_Renderer",
-            "Default_Scanline_Renderer",
-            "Quicksilver_Hardware_Renderer",
-        ] or renderer.startswith("V_Ray"):
+        if is_supported_renderer(renderer):
             self.render_element_layer(output, width, height, img_fmt)
 
         rt.rendSaveFile = True

--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -93,11 +93,9 @@ class RenderSettings(object):
         if renderer in [
             "ART_Renderer",
             "Redshift_Renderer",
-            "V_Ray_6_Hotfix_3",
-            "V_Ray_GPU_6_Hotfix_3",
             "Default_Scanline_Renderer",
             "Quicksilver_Hardware_Renderer",
-        ]:
+        ] or renderer.startswith("V_Ray"):
             self.render_element_layer(output, width, height, img_fmt)
 
         rt.rendSaveFile = True

--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -116,8 +116,7 @@ class RenderSettings(object):
 
         rt.rendSaveFile = True
 
-        if rt.renderSceneDialog.isOpen():
-            rt.renderSceneDialog.close()
+        rt.renderSceneDialog.update()
 
     def arnold_setup(self):
         # get Arnold RenderView run in the background

--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -22,6 +22,7 @@ SUPPORTED_RENDERERS = {
 }
 
 def is_supported_renderer(renderer_name: str) -> bool:
+    """Whether ayon-max supports the relevant renderer."""
     if renderer_name in SUPPORTED_RENDERERS:
         return True
     if renderer_name.startswith("V_Ray_"):

--- a/client/ayon_max/plugins/publish/validate_renderpasses.py
+++ b/client/ayon_max/plugins/publish/validate_renderpasses.py
@@ -94,11 +94,9 @@ class ValidateRenderPasses(OptionalPyblishPluginMixin,
         if renderer in [
             "ART_Renderer",
             "Redshift_Renderer",
-            "V_Ray_6_Hotfix_3",
-            "V_Ray_GPU_6_Hotfix_3",
             "Default_Scanline_Renderer",
             "Quicksilver_Hardware_Renderer",
-        ]:
+        ] or renderer.startswith("V_Ray"):
             render_elem = rt.maxOps.GetCurRenderElementMgr()
             render_elem_num = render_elem.NumRenderElements()
             for i in range(render_elem_num):
@@ -183,5 +181,6 @@ class ValidateRenderPasses(OptionalPyblishPluginMixin,
         container = instance.data.get("instance_node")
         # TODO: need to rename the function of render_output
         RenderSettings().render_output(container)
+        rt.renderSceneDialog.update()
         cls.log.debug("Finished repairing the render output "
                       "folder and filenames.")

--- a/client/ayon_max/plugins/publish/validate_renderpasses.py
+++ b/client/ayon_max/plugins/publish/validate_renderpasses.py
@@ -179,6 +179,5 @@ class ValidateRenderPasses(OptionalPyblishPluginMixin,
         container = instance.data.get("instance_node")
         # TODO: need to rename the function of render_output
         RenderSettings().render_output(container)
-        rt.renderSceneDialog.update()
         cls.log.debug("Finished repairing the render output "
                       "folder and filenames.")

--- a/client/ayon_max/plugins/publish/validate_renderpasses.py
+++ b/client/ayon_max/plugins/publish/validate_renderpasses.py
@@ -7,7 +7,10 @@ from ayon_core.pipeline.publish import (
     PublishValidationError,
     OptionalPyblishPluginMixin
 )
-from ayon_max.api.lib_rendersettings import RenderSettings
+from ayon_max.api.lib_rendersettings import (
+    RenderSettings,
+    is_supported_renderer
+)
 
 
 class ValidateRenderPasses(OptionalPyblishPluginMixin,
@@ -91,12 +94,7 @@ class ValidateRenderPasses(OptionalPyblishPluginMixin,
             instance, ext.lstrip("."))
         invalid.extend(invalid_image_format)
         renderer = instance.data["renderer"]
-        if renderer in [
-            "ART_Renderer",
-            "Redshift_Renderer",
-            "Default_Scanline_Renderer",
-            "Quicksilver_Hardware_Renderer",
-        ] or renderer.startswith("V_Ray"):
+        if is_supported_renderer(renderer):
             render_elem = rt.maxOps.GetCurRenderElementMgr()
             render_elem_num = render_elem.NumRenderElements()
             for i in range(render_elem_num):


### PR DESCRIPTION
## Changelog Description
This PR is to ensure render setting updated after repairing with validate renderpass(including hardcoded code).
This also ensure the render element created with Vray Renderer to be fixed correctly too.

Fix https://github.com/ynput/ayon-3dsmax/issues/43, https://github.com/ynput/ayon-3dsmax/issues/28, https://github.com/ynput/ayon-3dsmax/issues/42

## Additional review information
n/a

## Testing notes:
1. Use existing render instance to publish
2. Validation failed with Validate Renderpass with RenderSetting dialog not being closed
3. Perform Repair 
