### PR TITLE
Implementation of publishing vdb product 

### DIFF
--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -607,7 +607,7 @@ def render_resolution(width, height):
         rt.renderHeight = current_renderHeight
 
 
-def get_tyflow_export_operators():
+def get_tyflow_export_operators(operator_type="exportParticle"):
     """Get Tyflow Export Particles Operators.
 
     Returns:
@@ -615,6 +615,10 @@ def get_tyflow_export_operators():
 
     """
     operators = []
+    operator_prop = (
+        "exportMode" if operator_type == "exportParticle"
+        else "gridsSDF"
+    )
     members = [obj for obj in rt.Objects if rt.ClassOf(obj) == rt.tyFlow]
     for member in members:
         obj = member.baseobject
@@ -626,7 +630,7 @@ def get_tyflow_export_operators():
             node_names = rt.GetSubAnimNames(sub_anim)
             for node_name in node_names:
                 node_sub_anim = rt.GetSubAnim(sub_anim, node_name)
-                if rt.hasProperty(node_sub_anim, "exportMode"):
+                if rt.hasProperty(node_sub_anim, operator_prop):
                     operators.append(node_sub_anim)
     return operators
 
@@ -646,3 +650,30 @@ def suspended_refresh():
     finally:
         rt.enableSceneRedraw()
         rt.resumeEditing()
+
+
+@contextlib.contextmanager
+def animation_range_without_loop():
+    """Ensure animation range is played without
+    loop during context
+    """
+    previous_playbackLoop = (
+        rt.timeConfiguration.playbackLoop
+    )
+    previous_realtime_playback = (
+        rt.timeConfiguration.realTimePlayback
+    )
+    previous_current_frame = rt.currentTime.frame
+    rt.timeConfiguration.playbackLoop = False
+    rt.timeConfiguration.realTimePlayback = True
+    try:
+        yield
+
+    finally:
+        rt.timeConfiguration.playbackLoop = (
+            previous_playbackLoop
+        )
+        rt.timeConfiguration.realTimePlayback = (
+            previous_realtime_playback
+        )
+        rt.currentTime.frame = previous_current_frame

--- a/client/ayon_max/plugins/create/create_tyflow.py
+++ b/client/ayon_max/plugins/create/create_tyflow.py
@@ -9,3 +9,11 @@ class CreateTyFlow(plugin.MaxCacheCreator):
     label = "TyFlow"
     product_type = "tyflow"
     icon = "gear"
+
+
+class CreateTyVDB(plugin.MaxTyflowVDBCacheCreator):
+    """Creator plugin for TyFlow VDB."""
+    identifier = "io.ayon.creators.max.tyvdb"
+    label = "VDB (TyFlow)"
+    product_type = "tyflow_vdb"
+    icon = "gear"

--- a/client/ayon_max/plugins/publish/collect_tyflow_vdb.py
+++ b/client/ayon_max/plugins/publish/collect_tyflow_vdb.py
@@ -1,0 +1,74 @@
+import pyblish.api
+import re
+import copy
+from ayon_core.lib import BoolDef
+from ayon_max.api.lib import get_tyflow_export_operators
+from pymxs import runtime as rt
+
+
+class CollectTyFlowVDBData(pyblish.api.InstancePlugin):
+    """Collect TyFlow Attributes for VDB Export"""
+
+    order = pyblish.api.CollectorOrder + 0.005
+    label = "Collect TyFlow VDB attribute Data"
+    hosts = ['max']
+    families = ["tyflow_vdb"]
+    validate_tyvdb_frame_range = True
+
+    @classmethod
+    def apply_settings(cls, project_settings):
+
+        settings = (
+            project_settings["max"]["publish"]["ValidateTyVDBFrameRange"]
+        )
+        cls.validate_tyvdb_frame_range = settings["active"]
+
+    def process(self, instance):
+        context = instance.context
+        container_name = instance.data["instance_node"]
+        container = rt.GetNodeByName(container_name)
+        tyc_product_names = [
+            name for name
+            in container.modifiers[0].AYONTyCacheData.tyc_exports
+        ]
+        attr_values = self.get_attr_values_from_data(instance.data)
+        for tyc_product_name in tyc_product_names:
+            self.log.debug(f"Creating instance for operator:{tyc_product_name}")
+            tyc_instance = context.create_instance(tyc_product_name)
+            tyc_instance[:] = instance[:]
+            tyc_instance.data.update(copy.deepcopy(dict(instance.data)))
+            # Replace all runs of whitespace with underscore
+            prod_name = re.sub(r"\s+", "_", tyc_product_name)
+            operator = next((
+                    node for node in 
+                    get_tyflow_export_operators(operator="exportVDB")
+                    if node.name == tyc_product_name),
+                    None
+            )
+            tyc_instance.data.update({
+                "name": f"{container_name}_{prod_name}",
+                "label": f"{container_name}_{prod_name}",
+                "family": "vdb",
+                "families": ["vdb"],
+                "productName": f"{container_name}_{prod_name}",
+                # get the name of operator for the export
+                "operator": operator,
+                "productType": "vdb",
+                # make sure the tyflow vdb extractor would not be triggered
+                # when the non-tyflow vdb workflow is adopted by the user
+                # in the future
+                "is_tyflow": True,
+                "publish_attributes": {
+                    "ValidateTyVDBFrameRange": {
+                        "active": attr_values.get("has_frame_range_validator")}
+                }
+            })
+            instance.append(tyc_instance)
+
+    @classmethod
+    def get_attribute_defs(cls):
+        return [
+            BoolDef("has_frame_range_validator",
+                    label="Validate TyCache Frame Range",
+                    default=cls.validate_tyvdb_frame_range),
+        ]

--- a/client/ayon_max/plugins/publish/extract_tyflow_vdb.py
+++ b/client/ayon_max/plugins/publish/extract_tyflow_vdb.py
@@ -1,0 +1,125 @@
+import os
+import contextlib
+import pyblish.api
+from pymxs import runtime as rt
+
+from ayon_max.api.lib import (
+    maintained_selection,
+    animation_range_without_loop
+
+)
+
+from ayon_core.pipeline import publish
+
+
+class ExtractTyFlowVDB(publish.Extractor):
+    """Extract tycache format with tyFlow operators.
+    Notes:
+        - TyCache only works for TyFlow Pro Plugin.
+
+    Methods:
+        self._extract_tyflow_vdb: sets the necessary
+            attributes and export VDB with the export
+            particle operator(s)
+
+        self.get_files(): get the files with tyFlow naming convention
+            before publishing
+    """
+
+    order = pyblish.api.ExtractorOrder - 0.2
+    label = "Extract VDB (TyFlow)"
+    hosts = ["max"]
+    families = ["vdb"]
+
+    def process(self, instance):
+        if not instance.data.get("is_tyflow", False):
+            self.log.debug(
+                "Skipping instances due to non-tyflow VDB workflow used."
+            )
+            return
+
+        self.log.debug("Extracting VDB...")
+
+        stagingdir = self.staging_dir(instance)
+        operator = instance.data["operator"]
+        representations = instance.data.setdefault("representations", [])
+        start_frame = instance.data["frameStartHandle"]
+        end_frame = instance.data["frameEndHandle"]
+
+        product_name = instance.data.get("productName")
+        filename = f"{product_name}.vdb"
+        path = os.path.join(stagingdir, filename)
+
+        vdb_fnames = self.get_files(
+            product_name, start_frame, end_frame)
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(maintained_selection())
+            stack.enter_context(animation_range_without_loop())
+            self._extract_tyflow_vdb(
+                operator, start_frame, end_frame, path
+            )
+
+        representation = {
+            "name": "vdb",
+            "ext": "vdb",
+            "files": (
+                vdb_fnames if len(vdb_fnames) > 1
+                else vdb_fnames[0]),
+            "stagingDir": stagingdir
+        }
+        representations.append(representation)
+
+    def get_files(self, product_name, start_frame, end_frame):
+        """Get file names for tyFlow in VDB format.
+
+        Set the filenames accordingly to the VDB file
+        naming extension(.vdb) for the publishing purpose
+
+        Actual File Output from tyFlow in VDB format:
+        <InstanceName>_<operator>_<frame>.vdb
+
+        e.g. tyFlowMain_00000.vdb
+
+        Args:
+            product_name (str): product name
+            start_frame (int): frame start
+            end_frame (int): frame end
+
+        Returns:
+            filenames(list): list of filenames
+
+        """
+        filenames = []
+        for frame in range(int(start_frame), int(end_frame) + 1):
+            filename = f"{product_name}_{frame:05}.tyc"
+            filenames.append(filename)
+        return filenames
+
+    def _extract_tyflow_vdb(self, operator, frameStart, frameEnd, filepath):
+        """Exports VDB with the necessary export settings
+
+        Args:
+            operators (list): List of Export VDB operator
+            frameStart (int): Start frame.
+            frameEnd (int): End frame.
+            filepath (str): Output path of the VDB file.
+
+        """
+        export_settings = {
+            "timingIntervalStart": int(frameStart),
+            "timingIntervalEnd": int(frameEnd),
+            "autoExport": True,
+            "filename": filepath.replace("\\", "/"),
+        }
+
+        for key, value in export_settings.items():
+            rt.setProperty(operator, key, value)
+
+        # VDB would be exported when
+        # playing the animation in the timeline
+        rt.PlayAnimation(immediateReturn=False)
+        if not rt.isAnimPlaying():
+            self.log.debug(
+                "Successfully Extracted all VDB particles."
+            )

--- a/client/ayon_max/plugins/publish/validate_frame_range.py
+++ b/client/ayon_max/plugins/publish/validate_frame_range.py
@@ -125,3 +125,19 @@ class ValidateTyCacheFrameRange(ValidateFrameRange):
         if rt.hasProperty(operator, "exportMode"):
             operator.frameStart = frame_start_handle
             operator.frameEnd = frame_end_handle
+
+
+class ValidateTyVDBFrameRange(ValidateFrameRange):
+    label = "Validate Frame Range (TyFlow VDB)"
+    families = ["tyflow_vdb"]
+    optional = True
+
+    @classmethod
+    def repair(cls, instance):
+        frame_range = get_frame_range()
+        frame_start_handle = frame_range["frameStartHandle"]
+        frame_end_handle = frame_range["frameEndHandle"]
+        operator = instance.data["operator"]
+        if rt.hasProperty(operator, "gridsSDF"):
+            operator.timingIntervalStart = frame_start_handle
+            operator.timingIntervalEnd = frame_end_handle

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -92,6 +92,10 @@ class PublishersModel(BaseSettingsModel):
         default_factory=BasicValidateModel,
         title="Validate Frame Range (TyCache)"
     )
+    ValidateTyVDBFrameRange: BasicValidateModel = SettingsField(
+        default_factory=BasicValidateModel,
+        title="Validate Frame Range (TyFlow VDB)"
+    )
     ValidateAttributes: ValidateAttributesModel = SettingsField(
         default_factory=ValidateAttributesModel,
         title="Validate Attributes"
@@ -160,6 +164,11 @@ DEFAULT_PUBLISH_SETTINGS = {
     },
     "ValidateTyCacheFrameRange": {
         "enabled": False,
+        "optional": True,
+        "active": True
+    },
+    "ValidateTyVDBFrameRange": {
+        "enabled": True,
         "optional": True,
         "active": True
     },


### PR DESCRIPTION
## Changelog Description
This PR is to implement the publishing aspect for vdb product type. It is only supported for the vdb publish from TyFlow.

## Additional review information
- As vdb publishes can be supported by multiple external party plugins, so some of the codes are structured to make the implementation of vdb published from other parties easier to be integrated in the future.
- Make sure you included `Export VDB` operators in the tyflow editor, otherwises nothing shows up for publishing in the insrance container 
## Testing notes:
1. Create VDB (TyFlow)
2. Publish 
