### PR TITLE
Chore: Allow per project addon version

### DIFF
--- a/package.py
+++ b/package.py
@@ -4,6 +4,8 @@ version = "0.2.11+dev"
 app_host_name = "max"
 client_dir = "ayon_max"
 
+project_can_override_addon_version = True
+
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
     "core": ">0.3.2",


### PR DESCRIPTION
## Changelog Description
Addon can be used in per-project bundles.

## Additional informatio
I didn't find any conflicts that would not allow to use the addon in per project bundles.

## Testing notes:
1. Addon can be used in per-project bundles.
