### PR TITLE
Loader: Add folder name as unique namespace for loaded asset

### DIFF
--- a/client/ayon_max/plugins/load/load_camera_fbx.py
+++ b/client/ayon_max/plugins/load/load_camera_fbx.py
@@ -39,7 +39,8 @@ class FbxLoader(load.LoaderPlugin):
             using=rt.FBXIMP)
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         selections = rt.GetCurrentSelection()

--- a/client/ayon_max/plugins/load/load_image.py
+++ b/client/ayon_max/plugins/load/load_image.py
@@ -85,7 +85,8 @@ class ImageLoader(load.LoaderPlugin):
         file_path = os.path.normpath(self.filepath_from_context(context))
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         bitmap_type = options.get("bitmap_type", self.bitmap_default)

--- a/client/ayon_max/plugins/load/load_max_scene.py
+++ b/client/ayon_max/plugins/load/load_max_scene.py
@@ -114,7 +114,8 @@ class MaxSceneLoader(load.LoaderPlugin):
         max_container = []
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         for max_obj, obj_name in zip(max_objects, max_object_names):

--- a/client/ayon_max/plugins/load/load_model.py
+++ b/client/ayon_max/plugins/load/load_model.py
@@ -54,7 +54,8 @@ class ModelAbcLoader(load.LoaderPlugin):
 
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         abc_objects = []

--- a/client/ayon_max/plugins/load/load_model_fbx.py
+++ b/client/ayon_max/plugins/load/load_model_fbx.py
@@ -36,7 +36,8 @@ class FbxModelLoader(load.LoaderPlugin):
 
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         selections = rt.GetCurrentSelection()

--- a/client/ayon_max/plugins/load/load_model_obj.py
+++ b/client/ayon_max/plugins/load/load_model_obj.py
@@ -35,7 +35,8 @@ class ObjLoader(load.LoaderPlugin):
 
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         # create "missing" container for obj import

--- a/client/ayon_max/plugins/load/load_model_usd.py
+++ b/client/ayon_max/plugins/load/load_model_usd.py
@@ -46,7 +46,8 @@ class ModelUSDLoader(load.LoaderPlugin):
                                   importOptions=import_options)
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         asset = rt.GetNodeByName(name)

--- a/client/ayon_max/plugins/load/load_pointcache.py
+++ b/client/ayon_max/plugins/load/load_pointcache.py
@@ -63,7 +63,8 @@ class AbcLoader(load.LoaderPlugin):
 
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         abc_objects = []

--- a/client/ayon_max/plugins/load/load_pointcache_ornatrix.py
+++ b/client/ayon_max/plugins/load/load_pointcache_ornatrix.py
@@ -50,7 +50,8 @@ class OxAbcLoader(load.LoaderPlugin):
 
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         abc_container = []

--- a/client/ayon_max/plugins/load/load_pointcloud.py
+++ b/client/ayon_max/plugins/load/load_pointcloud.py
@@ -33,7 +33,8 @@ class PointCloudLoader(load.LoaderPlugin):
 
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         obj.name = f"{namespace}:{obj.name}"

--- a/client/ayon_max/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_max/plugins/load/load_redshift_proxy.py
@@ -37,7 +37,8 @@ class RedshiftProxyLoader(load.LoaderPlugin):
 
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         rs_obj.name = f"{namespace}:{rs_obj.name}"

--- a/client/ayon_max/plugins/load/load_tycache.py
+++ b/client/ayon_max/plugins/load/load_tycache.py
@@ -31,7 +31,8 @@ class TyCacheLoader(load.LoaderPlugin):
 
         folder_name = context["folder"]["name"]
         namespace = unique_namespace(
-            f"{folder_name}_{name}" + "_",
+            name + "_",
+            prefix=f"{folder_name}_",
             suffix="_",
         )
         obj.name = f"{namespace}:{obj.name}"


### PR DESCRIPTION
## Changelog Description
This PR is to add folder name as unique namespace for loaded asset to avoid the confusion across the folder type and task type.

## Additional review information
n/a

## Testing notes:
1. Load Asset along with existing loaded assets
2. Versioning both are working as expected while removing both too.
