### PR TITLE
Addon Startup Directory Environment not included when submitting to render job

### DIFF
--- a/client/ayon_max/addon.py
+++ b/client/ayon_max/addon.py
@@ -13,6 +13,11 @@ class MaxAddon(AYONAddon, IHostAddon):
     host_name = "max"
 
     def add_implementation_envs(self, env, _app):
+        if os.getenv("AYON_RENDER_JOB") == "1":
+            # Avoid adding startup script paths when running in a render job,
+            # as this can cause issues with 3dsmax's commandline rendering
+            #  and is not needed in a render job context.
+            return
         # Add requirements to ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR
         new_addon_paths = [
             os.path.join(MAX_HOST_DIR, "startup")


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the environment variable for 3dsmax addon directory installation (i.e. `ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR`) does not happen when we are submitting to render job.
 Resolve https://github.com/ynput/ayon-3dsmax/issues/93
## Additional review information
n/a


## Testing notes:
1. Create Render Instance
2. Publish
