### PR TITLE
Render element name matched with the output render

### DIFF
--- a/client/ayon_max/addon.py
+++ b/client/ayon_max/addon.py
@@ -13,11 +13,6 @@ class MaxAddon(AYONAddon, IHostAddon):
     host_name = "max"
 
     def add_implementation_envs(self, env, _app):
-        if os.getenv("AYON_RENDER_JOB") == "1":
-            # Avoid adding startup script paths when running in a render job,
-            # as this can cause issues with 3dsmax's commandline rendering
-            #  and is not needed in a render job context.
-            return
         # Add requirements to ADSK_3DSMAX_STARTUPSCRIPTS_ADDON_DIR
         new_addon_paths = [
             os.path.join(MAX_HOST_DIR, "startup")


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the expectedFile list matched with the render output when using render element
Discover this issue when looking at [ynput/ayon-deadline#232](https://github.com/ynput/ayon-deadline/pull/232)

## Additional review information
n/a

## Testing notes:
1. Create Render Instance
2. Publish