### PR TITLE
Do not reset viewports or create menus in headless mode

### DIFF
--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -483,8 +483,13 @@ def is_headless():
     If it returns True, it runs in 3dsbatch.exe
     If it returns False, it runs in 3dsmax.exe
     """
-    return rt.maxops.isInNonInteractiveMode()
-
+    return (
+        rt.maxops.isInNonInteractiveMode()
+        # It seems that Deadline render jobs even though headless do not
+        # register as 'non-interactive-mode' so we just assume any
+        # AYON_RENDER_JOB will be headless
+        or os.getenv("AYON_RENDER_JOB") == "1"
+    )
 
 def set_timeline(frameStart, frameEnd):
     """Set frame range for timeline editor in Max

--- a/client/ayon_max/api/menu.py
+++ b/client/ayon_max/api/menu.py
@@ -37,6 +37,7 @@ class AYONMenu(object):
     """
 
     def __init__(self):
+        print("Installing AYON menu...")
         super().__init__()
         self.main_widget = self.get_main_widget()
         self.menu = None

--- a/client/ayon_max/api/menu.py
+++ b/client/ayon_max/api/menu.py
@@ -25,6 +25,10 @@ from .workfile_template_builder import (
     update_placeholder
 )
 
+import logging
+
+log = logging.getLogger(__name__)
+
 
 class AYONMenu(object):
     """Object representing AYON menu.
@@ -37,7 +41,7 @@ class AYONMenu(object):
     """
 
     def __init__(self):
-        print("Installing AYON menu...")
+        log.info("Installing AYON menu...")
         super().__init__()
         self.main_widget = self.get_main_widget()
         self.menu = None

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -88,6 +88,9 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_creator_plugin_path(CREATE_PATH)
         register_workfile_build_plugin_path(WORKFILE_BUILD_PATH)
 
+        if lib.is_headless():
+            return
+
         print("AYON Set Project...")
         _set_project()
         print("AYON Set Autobackup Dir...")

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -140,7 +140,7 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             _on_scene_open,
             id=rt.name("AyonCallbacks")
         )
-        if lib.get_max_version() < 2026:
+        if not lib.is_headless() and lib.get_max_version() < 2026:
             rt.callbacks.addScript(
                 rt.Name('postWorkspaceChange'),
                 self._deferred_menu_creation,
@@ -150,7 +150,7 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             nameChanged=lib.update_modifier_node_names)
 
     def on_init(self):
-        if not self.menu:
+        if not lib.is_headless() and not self.menu:
             self._deferred_menu_creation()
         _on_scene_init()
 
@@ -371,7 +371,8 @@ def _set_project():
                 os.makedirs(proj_dir, exist_ok=True)
 
     # avoid glitching viewport
-    rt.viewport.ResetAllViews()
+    if not lib.is_headless():
+        rt.viewport.ResetAllViews()
 
 
 def _set_autobackup_dir():

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -79,8 +79,8 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         )
 
     def install(self):
-        print("Installing AYON 3dsmax host integration...")
-        print("Registering AYON plug-ins...")
+        log.info("Installing AYON 3dsmax host integration...")
+        log.info("Registering AYON plug-ins...")
         pyblish.api.register_host("max")
 
         pyblish.api.register_plugin_path(PUBLISH_PATH)
@@ -91,12 +91,12 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         if lib.is_headless():
             return
 
-        print("AYON Set Project...")
+        log.info("AYON Set Project...")
         _set_project()
-        print("AYON Set Autobackup Dir...")
+        log.info("AYON Set Autobackup Dir...")
         _set_autobackup_dir()
 
-        print("AYON Registering event callbacks...")
+        log.info("AYON Registering event callbacks...")
         register_event_callback("init", on_init)
         register_event_callback("new", on_new)
         register_event_callback("workfile.open.before", on_before_open)
@@ -104,7 +104,7 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_event_callback("before.save", before_save)
         register_event_callback("taskChanged", self.on_task_changed)
         self._has_been_setup = True
-        print("AYON Registering 3dsmax callbacks...")
+        log.info("AYON Registering 3dsmax callbacks...")
         self._register_callbacks()
 
     def workfile_has_unsaved_changes(self):
@@ -414,7 +414,7 @@ def before_save(event):
         return
 
     if max_filename_before != max_filename_after:
-        print(f"Detected scene name change from {max_filename_before} to "
+        log.info(f"Detected scene name change from {max_filename_before} to "
               f"{max_filename_after}")
     max_filename_before = os.path.splitext(max_filename_before)[0]
     max_filename_after = os.path.splitext(max_filename_after)[0]

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -79,6 +79,8 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         )
 
     def install(self):
+        print("Installing AYON 3dsmax host integration...")
+        print("Registering AYON plug-ins...")
         pyblish.api.register_host("max")
 
         pyblish.api.register_plugin_path(PUBLISH_PATH)
@@ -86,9 +88,12 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_creator_plugin_path(CREATE_PATH)
         register_workfile_build_plugin_path(WORKFILE_BUILD_PATH)
 
+        print("AYON Set Project...")
         _set_project()
+        print("AYON Set Autobackup Dir...")
         _set_autobackup_dir()
 
+        print("AYON Registering event callbacks...")
         register_event_callback("init", on_init)
         register_event_callback("new", on_new)
         register_event_callback("workfile.open.before", on_before_open)
@@ -96,6 +101,7 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_event_callback("before.save", before_save)
         register_event_callback("taskChanged", self.on_task_changed)
         self._has_been_setup = True
+        print("AYON Registering 3dsmax callbacks...")
         self._register_callbacks()
 
     def workfile_has_unsaved_changes(self):

--- a/client/ayon_max/startup/startup.py
+++ b/client/ayon_max/startup/startup.py
@@ -1,6 +1,10 @@
+import logging
+
 from ayon_max.api import MaxHost
 from ayon_core.pipeline import install_host
 
-print("Installing AYON Max Host (startup.py)")
+log = logging.getLogger(__name__)
+
+log.info("Installing AYON Max Host (startup.py)")
 host = MaxHost()
 install_host(host)

--- a/client/ayon_max/startup/startup.py
+++ b/client/ayon_max/startup/startup.py
@@ -1,5 +1,6 @@
 from ayon_max.api import MaxHost
 from ayon_core.pipeline import install_host
 
+print("Installing AYON Max Host (startup.py)")
 host = MaxHost()
 install_host(host)


### PR DESCRIPTION
## Changelog Description

Do not reset viewports or create menus in headless mode to avoid holding the 3dsmax render and making it fail.

## Additional review information

Potential alternative to https://github.com/ynput/ayon-3dsmax/pull/100 to fix https://github.com/ynput/ayon-3dsmax/issues/93

## Testing notes:

1. Test whether this renders on farm correctly now