### PR TITLE
Use renderelement.name for render output when creating instance

### DIFF
--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -137,7 +137,6 @@ class RenderSettings(object):
         elif renderer == "Redshift_Renderer":
             rt.rendOutputFilename = output_filename
             rt.renderers.current.separateAovFiles = multipass_enabled
-            self.render_element_layer(output, width, height, img_fmt)
             if img_fmt == "exr" and multipass_enabled:
                 rt.renderers.current.OutputExrMultipart = multipass_enabled
 


### PR DESCRIPTION
## Changelog Description
This PR is to make sure render outputs from creating instance matching with the expected files. 
As we have made some changes in the previous release, we use render.elementname instead of old renderelement.type
Resolve https://github.com/ynput/ayon-3dsmax/issues/119
## Additional review information
n/a.

## Testing notes:
1. Create Render
2. Publish
