### PR TITLE
Current File: Use already collected 'currentFile'

### DIFF
--- a/client/ayon_max/plugins/publish/collect_current_file.py
+++ b/client/ayon_max/plugins/publish/collect_current_file.py
@@ -19,7 +19,7 @@ class CollectCurrentFile(pyblish.api.ContextPlugin):
             self.log.error("Scene is not saved.")
 
         if platform.system().lower() == "windows":
-            current_file = current_file.reaplace("\\", "/")
+            current_file = current_file.replace("\\", "/")
 
         context.data["currentFile"] = current_file
         self.log.debug("Scene path: {}".format(current_file))

--- a/client/ayon_max/plugins/publish/collect_current_file.py
+++ b/client/ayon_max/plugins/publish/collect_current_file.py
@@ -1,3 +1,5 @@
+import platform
+
 import pyblish.api
 from ayon_core.pipeline import registered_host
 
@@ -15,6 +17,9 @@ class CollectCurrentFile(pyblish.api.ContextPlugin):
         current_file = host.get_current_workfile()
         if not current_file:
             self.log.error("Scene is not saved.")
+
+        if platform.system().lower() == "windows":
+            current_file = current_file.reaplace("\\", "/")
 
         context.data["currentFile"] = current_file
         self.log.debug("Scene path: {}".format(current_file))

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -39,13 +39,8 @@ class CollectRender(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         context = instance.context
-        folder = rt.maxFilePath
-        file = rt.maxFileName
-        current_file = os.path.join(folder, file)
-        filename = os.path.splitext(file)[0]
-        self.log.debug(f"Current: {filename}")
-        filepath = current_file.replace("\\", "/")
-        context.data['currentFile'] = current_file
+        current_file = context.data["currentFile"]
+        filename = os.path.basename(current_file)
         renderer_class = get_current_renderer()
         renderer = str(renderer_class).split(":")[0]
         render_dir = os.path.dirname(rt.rendOutputFilename)

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -39,8 +39,8 @@ class CollectRender(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         context = instance.context
-        current_file = context.data["currentFile"]
-        filename = os.path.basename(current_file)
+        filepath = context.data["currentFile"]
+        filename = os.path.basename(filepath)
         renderer_class = get_current_renderer()
         renderer = str(renderer_class).split(":")[0]
         render_dir = os.path.dirname(rt.rendOutputFilename)


### PR DESCRIPTION
## Changelog Description
Collect render plugin is re-using currentFile which is already collected in CollectCurrentWorkfile plugin.

## Additional review information
Collect render did what `CollectCurrentWorkfile ` already did. CollectRender did replace `\` with `/` for some reason, not sure if that should be put back?

## Testing notes:
1. Publishing should work as did.
