### PR TITLE
Repair Action for Validate Render Settings should repair render element for Redshift

### DIFF
--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1040,18 +1040,15 @@ def set_correct_workfile_name_for_render_output(
 def build_general_output_filename(
     output_dir: str,
     filename: str,
-    image_format: str,
 ) -> str:
     """Build a general output filename with the given directory, filename, and image format.
 
     Args:
         output_dir (str): The directory where the output file will be saved.
         filename (str): The base filename.
-        image_format (str): The image format/extension.
 
     Returns:
         str: The full path to the output file with the general naming convention.
     """
-    name = os.path.splitext(filename)[0]
-    output_filename = f"{name}.{image_format}"
-    return os.path.join(output_dir, output_filename)
+    filename = reformat_filename(filename)
+    return os.path.join(output_dir, filename)

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1050,5 +1050,13 @@ def build_general_output_filename(
     Returns:
         str: The full path to the output file with the general naming convention.
     """
-    filename = reformat_filename(filename)
+    generic_pattern = (
+        r"^(?P<name>.+)\._(?P<element>[^.]+)\.(?P<ext>[a-zA-Z0-9]+)$"
+    )
+    match = re.match(generic_pattern, filename)
+    if match:
+        name = match.group("name")
+        element = match.group("element")
+        ext = match.group("ext")
+        filename = f"{name}_{element}..{ext}"
     return os.path.join(output_dir, filename)

--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -314,6 +314,7 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
                 "Render element output filename has been repaired to %s",
                 render_elem.GetRenderElementFilename(index),
             )
+        rt.renderSceneDialog.update()
 
 
 class ValidateArnoldRenderSetting(ValidateGenericRenderSetting):

--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -286,7 +286,6 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
         rt.rendOutputFilename = build_general_output_filename(
             output_dir,
             filename,
-            image_format,
         )
         cls.log.info(
             "Render output filename has been repaired to %s",
@@ -309,9 +308,7 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
                 instance,
                 os.path.dirname(render_element_filename),
             )
-            output_filename = build_general_output_filename(
-                output_dir, r_fname, image_format
-            )
+            output_filename = build_general_output_filename(output_dir, r_fname)
             render_elem.SetRenderElementFilename(index, output_filename)
             cls.log.info(
                 "Render element output filename has been repaired to %s",
@@ -481,7 +478,6 @@ class ValidateArnoldRenderSetting(ValidateGenericRenderSetting):
         rt.rendOutputFilename = build_general_output_filename(
             render_dir,
             filename,
-            image_format,
         )
         driver = aov_manager.drivers[0]
         driver.multipart = get_multipass_setting(


### PR DESCRIPTION
## Changelog Description
This PR is to ensure repair action for Validate Render Setting should work for fixing Redshift Render Element Filename.
Resolve: https://github.com/ynput/ayon-3dsmax/issues/128

## Additional review information
n/a

## Testing notes:
1. Create Render 
2. Add some RS render elements
3. Publish
4. Validation blocks
5. Repair Action
6. Publish
7. Should be successful
