### PR TITLE
Add custom frame range support for local rendering

### DIFF
--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1082,11 +1082,31 @@ def get_expected_frames(instance: pyblish.api.Instance) -> list[int]:
         """
         frames = []
         for part in frame_str.split(","):
+            part = part.strip()
+            if not part:
+                continue
+
             if "-" in part:
-                start, end = map(int, part.split("-"))
+                start_end = part.split("-", 1)
+                if len(start_end) != 2 or not start_end[0] or not start_end[1]:
+                    raise ValueError(
+                        f"Invalid frame range segment: '{part}'"
+                    )
+
+                start, end = map(int, start_end)
+                if start > end:
+                    raise ValueError(
+                        f"Frame range start must be less than or equal "
+                        f"to end: '{part}'"
+                    )
                 frames.extend(range(start, end + 1))
             else:
                 frames.append(int(part))
+
+        if not frames:
+            raise ValueError(
+                f"No valid frames could be parsed from '{frame_str}'"
+            )
         return frames
 
     frames = instance.data["custom_frames"]

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1060,3 +1060,36 @@ def build_general_output_filename(
         ext = match.group("ext")
         filename = f"{name}_{element}..{ext}"
     return os.path.join(output_dir, filename)
+
+
+def get_expected_frames(instance: pyblish.api.Instance) -> list[int]:
+    """Get expected frames from the instance.
+
+    Args:
+        instance (pyblish.api.Instance): The Pyblish instance.
+
+    Returns:
+        list[int]: A list containing the expected frames.
+    """
+    def parse_frame_range(frame_str: str) -> list[int]:
+        """Parse a frame range string into a list of frames.
+
+        Args:
+            frame_str (str): The frame range string.
+
+        Returns:
+            list[int]: A list of frames.
+        """
+        frames = []
+        for part in frame_str.split(","):
+            if "-" in part:
+                start, end = map(int, part.split("-"))
+                frames.extend(range(start, end + 1))
+            else:
+                frames.append(int(part))
+        return frames
+
+    frames = instance.data["custom_frames"]
+    if instance.data["custom_frames"]:
+        return parse_frame_range(frames)
+    return list(range(instance.data["frameStart"], instance.data["frameEnd"] + 1))

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1092,4 +1092,4 @@ def get_expected_frames(instance: pyblish.api.Instance) -> list[int]:
     frames = instance.data["custom_frames"]
     if instance.data["custom_frames"]:
         return parse_frame_range(frames)
-    return list(range(instance.data["frameStart"], instance.data["frameEnd"] + 1))
+    return list(range(rt.rendStart, rt.rendEnd + 1))

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -29,8 +29,9 @@ from ayon_core.pipeline.context_tools import (
     get_current_task_entity
 )
 from ayon_core.pipeline.template_data import get_template_data_with_names
-from ayon_core.pipeline.farm.pyblish_functions import \
-    convert_frames_str_to_list
+from ayon_core.pipeline.farm.pyblish_functions import (
+    convert_frames_str_to_list,
+)
 from ayon_core.pipeline.create import CreateContext
 from ayon_core.style import load_stylesheet
 

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -23,6 +23,8 @@ from ayon_core.settings import get_project_settings
 from ayon_core.pipeline.context_tools import (
     get_current_task_entity
 )
+from ayon_core.pipeline.farm.pyblish_functions import \
+    convert_frames_str_to_list
 from ayon_core.pipeline.create import CreateContext
 from ayon_core.style import load_stylesheet
 
@@ -1071,47 +1073,9 @@ def get_expected_frames(instance: pyblish.api.Instance) -> list[int]:
     Returns:
         list[int]: A list containing the expected frames.
     """
-    def parse_frame_range(frame_str: str) -> list[int]:
-        """Parse a frame range string into a list of frames.
-
-        Args:
-            frame_str (str): The frame range string.
-
-        Returns:
-            list[int]: A list of frames.
-        """
-        frames = []
-        for part in frame_str.split(","):
-            part = part.strip()
-            if not part:
-                continue
-
-            if "-" in part:
-                start_end = part.split("-", 1)
-                if len(start_end) != 2 or not start_end[0] or not start_end[1]:
-                    raise ValueError(
-                        f"Invalid frame range segment: '{part}'"
-                    )
-
-                start, end = map(int, start_end)
-                if start > end:
-                    raise ValueError(
-                        f"Frame range start must be less than or equal "
-                        f"to end: '{part}'"
-                    )
-                frames.extend(range(start, end + 1))
-            else:
-                frames.append(int(part))
-
-        if not frames:
-            raise ValueError(
-                f"No valid frames could be parsed from '{frame_str}'"
-            )
-        return frames
-
     frames = instance.data.get("customFrames", "")
     if frames:
-        return parse_frame_range(frames)
+        return convert_frames_str_to_list(frames)
     frame_start = int(rt.rendStart)
     frame_end = int(rt.rendEnd)
     return list(range(frame_start, frame_end + 1))

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1109,7 +1109,9 @@ def get_expected_frames(instance: pyblish.api.Instance) -> list[int]:
             )
         return frames
 
-    frames = instance.data["custom_frames"]
-    if instance.data["custom_frames"]:
+    frames = instance.data.get("custom_frames", "")
+    if frames:
         return parse_frame_range(frames)
-    return list(range(rt.rendStart, rt.rendEnd + 1))
+    frame_start = int(rt.rendStart)
+    frame_end = int(rt.rendEnd)
+    return list(range(frame_start, frame_end + 1))

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1109,7 +1109,7 @@ def get_expected_frames(instance: pyblish.api.Instance) -> list[int]:
             )
         return frames
 
-    frames = instance.data.get("custom_frames", "")
+    frames = instance.data.get("customFrames", "")
     if frames:
         return parse_frame_range(frames)
     frame_start = int(rt.rendStart)

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -18,6 +18,7 @@ from ayon_core.pipeline import (
     AYON_INSTANCE_ID,
     AVALON_INSTANCE_ID,
 )
+from ayon_core.pipeline.publish import PublishError
 from ayon_core.tools.utils import SimplePopup
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline.context_tools import (
@@ -1073,9 +1074,16 @@ def get_expected_frames(instance: pyblish.api.Instance) -> list[int]:
     Returns:
         list[int]: A list containing the expected frames.
     """
-    frames = instance.data.get("customFrames", "")
-    if frames:
-        return convert_frames_str_to_list(frames)
+    frames_str = instance.data.get("customFrames", "")
+    if frames_str:
+        frames_list = convert_frames_str_to_list(frames_str.strip())
+        frames_list = sorted({int(frame) for frame in frames_list})
+        if not frames_list:
+            raise PublishError(
+                f"Invalid customFrames value: {frames_str}. "
+                "Expected a comma-separated list of integers or ranges."
+            )
+        return frames_list
     frame_start = int(rt.rendStart)
     frame_end = int(rt.rendEnd)
     return list(range(frame_start, frame_end + 1))

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -22,7 +22,6 @@ from ayon_core.pipeline import (
     AVALON_INSTANCE_ID,
 )
 from ayon_core.lib import StringTemplate, get_version_from_path
-from ayon_core.pipeline.publish import PublishError
 from ayon_core.tools.utils import SimplePopup
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline.context_tools import (

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1171,12 +1171,6 @@ def get_expected_frames(instance: pyblish.api.Instance) -> list[int]:
     frames_str = instance.data.get("customFrames", "")
     if frames_str:
         frames_list = convert_frames_str_to_list(frames_str.strip())
-        frames_list = sorted({int(frame) for frame in frames_list})
-        if not frames_list:
-            raise PublishError(
-                f"Invalid customFrames value: {frames_str}. "
-                "Expected a comma-separated list of integers or ranges."
-            )
         return frames_list
     frame_start = int(rt.rendStart)
     frame_end = int(rt.rendEnd)

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -89,6 +89,8 @@ class RenderProducts(object):
         Args:
             outputs (list[str]): A list of output file paths.
             cameras (list[str]): A list of camera names.
+            frame_range (list[int]): A list of frames to generate expected
+                output file paths for.
 
         Returns:
             Dict[str, list[str]]: A dictionary containing render output file

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -128,9 +128,8 @@ class RenderProducts(object):
         """Get expected beauty render output file paths for each frame.
 
         Args:
-            frame_range (list[int]): The range of frames.
-
-            end_frame (int): The ending frame number.
+            frame_range (list[int]): The frame range to generate expected
+                output file paths for.
             extension (str): The file extension for the output files.
 
         Returns:

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -44,6 +44,10 @@ class RenderProducts(object):
         Handles both beauty and AOV extraction with shared setup logic.
         Always includes the beauty pass; optionally includes render elements/AOVs.
 
+        Args:
+            frame_range (list[int]): A list of frames to generate expected
+                output file paths for.
+
         Returns:
             Dict[str, list[str]]: A dictionary containing render output file paths.
                 Beauty key is "beauty"; AOV keys are named after the render element

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -38,7 +38,7 @@ class RenderProducts(object):
                 get_current_project_name()
             )
 
-    def get_render_products(self) -> Dict[str, list[str]]:
+    def get_render_products(self, frame_range: list[int]) -> Dict[str, list[str]]:
         """Get render output file paths for the current scene.
 
         Handles both beauty and AOV extraction with shared setup logic.
@@ -50,8 +50,7 @@ class RenderProducts(object):
                 (e.g., "Cryptomatte", "Alpha").
         """
         extension = self.image_format()
-        start_frame = int(rt.rendStart)
-        end_frame = int(rt.rendEnd)
+
         # todo: Support Custom Frames sequences 0,5-10,100-120
         # we can add filtering frames list to get expected frames list
         # instead of using start and end frame
@@ -60,7 +59,7 @@ class RenderProducts(object):
         render_dict: Dict[str, list[str]] = {}
 
         # Always add beauty pass
-        render_dict["beauty"] = self.get_expected_beauty(start_frame, end_frame, extension)
+        render_dict["beauty"] = self.get_expected_beauty(frame_range, extension)
 
         # Optionally add AOVs
         renderer = get_current_renderer()
@@ -70,8 +69,7 @@ class RenderProducts(object):
             for aov_name, aov_filepath in render_elements:
                 aov_expected_files = self.get_expected_files(
                     aov_filepath,
-                    start_frame,
-                    end_frame,
+                    frame_range,
                     aov_name,
                     renderer_name
                 )
@@ -80,7 +78,7 @@ class RenderProducts(object):
         return render_dict
 
     def get_multiple_render_products(
-            self, outputs: list[str], cameras: list[str]
+            self, outputs: list[str], cameras: list[str], frame_range: list[int]
     ) -> Dict[str, list[str]]:
         """Get render output file paths for multiple cameras.
 
@@ -105,11 +103,9 @@ class RenderProducts(object):
             filename, ext = os.path.splitext(output)
             filename = filename.replace(".", "")
             ext = ext.replace(".", "")
-            start_frame = int(rt.rendStart)
-            end_frame = int(rt.rendEnd)
 
             # Always add beauty pass
-            beauty_files = self.get_expected_beauty(start_frame, end_frame, ext)
+            beauty_files = self.get_expected_beauty(frame_range, ext)
             render_output_frames[f"{camera}_beauty"] = beauty_files
 
             # Add AOVs
@@ -118,8 +114,7 @@ class RenderProducts(object):
                 for aov_name, aov_filepath in render_elements:
                     aov_expected_files = self.get_expected_files(
                         aov_filepath,
-                        start_frame,
-                        end_frame,
+                        frame_range,
                         aov_name,
                         renderer_name
                     )
@@ -128,12 +123,13 @@ class RenderProducts(object):
         return render_output_frames
 
     def get_expected_beauty(
-            self, start_frame: int, end_frame: int, extension: str
+            self, frame_range: list[int], extension: str
     ) -> list[str]:
         """Get expected beauty render output file paths for each frame.
 
         Args:
-            start_frame (int): The starting frame number.
+            frame_range (list[int]): The range of frames.
+
             end_frame (int): The ending frame number.
             extension (str): The file extension for the output files.
 
@@ -151,8 +147,7 @@ class RenderProducts(object):
 
         return self.get_expected_files(
             output_path,
-            start_frame,
-            end_frame,
+            frame_range,
             "",
             renderer_name
         )
@@ -258,8 +253,7 @@ class RenderProducts(object):
     def get_expected_files(
         self,
         filepath: str,
-        start_frame: int,
-        end_frame: int,
+        frame_range: list[int],
         aov_name: str,
         renderer_name: str,
     ) -> list[str]:
@@ -267,8 +261,7 @@ class RenderProducts(object):
 
         Args:
             filepath (str): filepath of the render output.
-            start_frame (int): start frame of the render sequence.
-            end_frame (int): end frame of the render sequence.
+            frame_range (list[int]): range of frames of the render sequence.
             aov_name (str): name of the AOV.
             renderer_name (str): name of the renderer.
 
@@ -281,7 +274,7 @@ class RenderProducts(object):
         name, ext = os.path.splitext(filename)
         name = name.lstrip(".")
         aov_name = aov_name.strip()
-        for frame in range(start_frame, end_frame + 1):
+        for frame in frame_range:
             aov_filename =  f"{name}.{frame:04d}{ext}"
             expected_aov = os.path.join(directory, aov_filename)
             if aov_name and renderer_name.startswith("V_Ray_"):

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -38,14 +38,14 @@ class RenderProducts(object):
                 get_current_project_name()
             )
 
-    def get_render_products(self, frame_range: list[int]) -> Dict[str, list[str]]:
+    def get_render_products(self, frames: list[int]) -> Dict[str, list[str]]:
         """Get render output file paths for the current scene.
 
         Handles both beauty and AOV extraction with shared setup logic.
         Always includes the beauty pass; optionally includes render elements/AOVs.
 
         Args:
-            frame_range (list[int]): A list of frames to generate expected
+            frames (list[int]): A list of frames to generate expected
                 output file paths for.
 
         Returns:
@@ -63,7 +63,7 @@ class RenderProducts(object):
         render_dict: Dict[str, list[str]] = {}
 
         # Always add beauty pass
-        render_dict["beauty"] = self.get_expected_beauty(frame_range, extension)
+        render_dict["beauty"] = self.get_expected_beauty(frames, extension)
 
         # Optionally add AOVs
         renderer = get_current_renderer()
@@ -73,7 +73,7 @@ class RenderProducts(object):
             for aov_name, aov_filepath in render_elements:
                 aov_expected_files = self.get_expected_files(
                     aov_filepath,
-                    frame_range,
+                    frames,
                     aov_name,
                     renderer_name
                 )
@@ -81,7 +81,7 @@ class RenderProducts(object):
         return render_dict
 
     def get_multiple_render_products(
-            self, outputs: list[str], cameras: list[str], frame_range: list[int]
+            self, outputs: list[str], cameras: list[str], frames: list[int]
     ) -> Dict[str, list[str]]:
         """Get render output file paths for multiple cameras.
 
@@ -92,7 +92,7 @@ class RenderProducts(object):
         Args:
             outputs (list[str]): A list of output file paths.
             cameras (list[str]): A list of camera names.
-            frame_range (list[int]): A list of frames to generate expected
+            frames (list[int]): A list of frames to generate expected
                 output file paths for.
 
         Returns:
@@ -110,7 +110,7 @@ class RenderProducts(object):
             ext = ext.replace(".", "")
 
             # Always add beauty pass
-            beauty_files = self.get_expected_beauty(frame_range, ext)
+            beauty_files = self.get_expected_beauty(frames, ext)
             render_output_frames[f"{camera}_beauty"] = beauty_files
 
             # Add AOVs
@@ -119,7 +119,7 @@ class RenderProducts(object):
                 for aov_name, aov_filepath in render_elements:
                     aov_expected_files = self.get_expected_files(
                         aov_filepath,
-                        frame_range,
+                        frames,
                         aov_name,
                         renderer_name
                     )
@@ -128,12 +128,12 @@ class RenderProducts(object):
         return render_output_frames
 
     def get_expected_beauty(
-            self, frame_range: list[int], extension: str
+            self, frames: list[int], extension: str
     ) -> list[str]:
         """Get expected beauty render output file paths for each frame.
 
         Args:
-            frame_range (list[int]): The frame range to generate expected
+            frames (list[int]): The frame range to generate expected
                 output file paths for.
             extension (str): The file extension for the output files.
 
@@ -151,7 +151,7 @@ class RenderProducts(object):
 
         return self.get_expected_files(
             output_path,
-            frame_range,
+            frames,
             "",
             renderer_name
         )
@@ -263,7 +263,7 @@ class RenderProducts(object):
     def get_expected_files(
         self,
         filepath: str,
-        frame_range: list[int],
+        frames: list[int],
         aov_name: str,
         renderer_name: str,
     ) -> list[str]:
@@ -271,7 +271,7 @@ class RenderProducts(object):
 
         Args:
             filepath (str): filepath of the render output.
-            frame_range (list[int]): range of frames of the render sequence.
+            frames (list[int]): range of frames of the render sequence.
             aov_name (str): name of the AOV.
             renderer_name (str): name of the renderer.
 
@@ -286,7 +286,7 @@ class RenderProducts(object):
         name, ext = os.path.splitext(filename)
         name = name.lstrip(".")
         aov_name = aov_name.strip()
-        for frame in frame_range:
+        for frame in frames:
             aov_filename =  f"{name}.{frame:04d}{ext}"
             expected_aov = os.path.join(directory, aov_filename)
             if aov_name and renderer_name.startswith("V_Ray_"):

--- a/client/ayon_max/plugins/publish/collect_frame_range.py
+++ b/client/ayon_max/plugins/publish/collect_frame_range.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 import pyblish.api
 from pymxs import runtime as rt
+from ayon_max.api.lib import get_expected_frames
 
 
 class CollectFrameRange(pyblish.api.InstancePlugin):
     """Collect Frame Range."""
 
-    order = pyblish.api.CollectorOrder + 0.011
+    order = pyblish.api.CollectorOrder + 0.019
     label = "Collect Frame Range"
     hosts = ['max']
     families = ["camera", "maxrender",
@@ -16,8 +17,10 @@ class CollectFrameRange(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         if instance.data["productBaseType"] == "maxrender":
-            instance.data["frameStartHandle"] = int(rt.rendStart)
-            instance.data["frameEndHandle"] = int(rt.rendEnd)
+            frame_range = get_expected_frames(instance)
+            instance.data["frameStartHandle"] = min(frame_range)
+            instance.data["frameEndHandle"] = max(frame_range)
+            instance.data["expectedFrameRange"] = frame_range
 
         elif instance.data["productBaseType"] in {"tycache", "tyspline"}:
             operator = instance.data["operator"]

--- a/client/ayon_max/plugins/publish/collect_frame_range.py
+++ b/client/ayon_max/plugins/publish/collect_frame_range.py
@@ -7,6 +7,8 @@ from ayon_max.api.lib import get_expected_frames
 class CollectFrameRange(pyblish.api.InstancePlugin):
     """Collect Frame Range."""
 
+    # move the collector order later to ensure
+    # it run after CollectCustomFrameRange in Core addon
     order = pyblish.api.CollectorOrder + 0.019
     label = "Collect Frame Range"
     hosts = ['max']

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -60,7 +60,8 @@ class CollectRender(pyblish.api.InstancePlugin):
         renderer_name = str(renderer).split(":")[0]
         renderproducts = RenderProducts(context.data["project_settings"])
         img_format = renderproducts.image_format()
-        files_by_aov: Dict[str, list[str]] = renderproducts.get_render_products()
+        expected_frames = instance.data.get("expectedFrameRange", [])
+        files_by_aov: Dict[str, list[str]] = renderproducts.get_render_products(expected_frames)
 
 
         camera = rt.viewport.GetCamera()
@@ -94,7 +95,7 @@ class CollectRender(pyblish.api.InstancePlugin):
             instance.data["cameras"] = sel_cam
 
             files_by_aov = renderproducts.get_multiple_render_products(
-                outputs, sel_cam
+                outputs, sel_cam, expected_frames
             )
 
         if "expectedFiles" not in instance.data:

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -112,18 +112,6 @@ class CollectRender(pyblish.api.InstancePlugin):
         if colorspace_data:
             instance.data.update(colorspace_data)
 
-        colorspace_product = colorspace.ARenderProduct(
-            instance.data["frameStartHandle"],
-            instance.data["frameEndHandle"]
-        )
-        colorspace_product.add_colorspace_data(
-            product_name=str(instance.name),
-            colorspace=colorspace_data.get("colorspace", "sRGB"),
-            view=colorspace_data.get("sceneView", "ACES 1.0"),
-            display=colorspace_data.get("sceneDisplay", "sRGB")
-        )
-        instance.data["renderProducts"] = colorspace_product
-
         instance.data["publishJobState"] = "Suspended"
         instance.data["attachTo"] = []
 
@@ -141,7 +129,20 @@ class CollectRender(pyblish.api.InstancePlugin):
         )
         self._precollect_required_data(instance)
 
-        # also need to get the render dir for conversion
+        # set the colorspace data for each AOV in the instance data
+        for aov_name in files_by_aov.keys():
+            colorspace_product = colorspace.ARenderProduct(
+                instance.data["frameStartHandle"],
+                instance.data["frameEndHandle"]
+            )
+            colorspace_product.add_colorspace_data(
+                product_name=aov_name,
+                colorspace=colorspace_data.get("colorspace", "sRGB"),
+                view=colorspace_data.get("sceneView", "ACES 1.0"),
+                display=colorspace_data.get("sceneDisplay", "sRGB")
+            )
+            instance.data["renderProducts"] = colorspace_product
+
         data = {
             "folderPath": instance.data["folderPath"],
             "workfile_name": filename,

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -62,8 +62,6 @@ class CollectRender(pyblish.api.InstancePlugin):
         renderproducts = RenderProducts(context.data["project_settings"])
         img_format = renderproducts.image_format()
         expected_frames = instance.data.get("expectedFrameRange")
-        if not expected_frames:
-            expected_frames = list(range(int(rt.rendStart), int(rt.rendEnd) + 1))
         files_by_aov: Dict[str, list[str]] = renderproducts.get_render_products(expected_frames)
 
 

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -61,7 +61,9 @@ class CollectRender(pyblish.api.InstancePlugin):
         renderer_name = str(renderer).split(":")[0]
         renderproducts = RenderProducts(context.data["project_settings"])
         img_format = renderproducts.image_format()
-        expected_frames = instance.data.get("expectedFrameRange", [])
+        expected_frames = instance.data.get("expectedFrameRange")
+        if not expected_frames:
+            expected_frames = list(range(int(rt.rendStart), int(rt.rendEnd) + 1))
         files_by_aov: Dict[str, list[str]] = renderproducts.get_render_products(expected_frames)
 
 

--- a/client/ayon_max/plugins/publish/collect_render_local.py
+++ b/client/ayon_max/plugins/publish/collect_render_local.py
@@ -80,7 +80,7 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
 
             # The hasExplicitFrames flag controls whether frame indices are renumbered.
             # Setting this to True ensures the published frames keep their original numbering
-            # and are not shifted during integration with the AOV server.
+            # and are not shifted during integration with the AYON server.
             aov_instance.data["hasExplicitFrames"] = True
 
             # Pass on 'review' family

--- a/client/ayon_max/plugins/publish/collect_render_local.py
+++ b/client/ayon_max/plugins/publish/collect_render_local.py
@@ -78,10 +78,10 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
             aov_instance.data.update(aov_instance_data)
             aov_instance.data["families"] = [f"render.{render_target}"]
 
+            # The hasExplicitFrames flag controls whether frame indices are renumbered.
+            # Setting this to True ensures the published frames keep their original numbering
+            # and are not shifted during integration with the AOV server.
             aov_instance.data["hasExplicitFrames"] = True
-            aov_instance.data["reuseLastVersion"] = instance.data.get(
-                "reuse_last_version", False
-            )
 
             # Pass on 'review' family
             if "review" in aov_instance_data["families"]:

--- a/client/ayon_max/plugins/publish/collect_render_local.py
+++ b/client/ayon_max/plugins/publish/collect_render_local.py
@@ -74,6 +74,11 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
             aov_instance.data.update(aov_instance_data)
             aov_instance.data["families"] = [f"render.{render_target}"]
 
+            aov_instance.data["hasExplicitFrames"] = True
+            aov_instance.data["reuseLastVersion"] = instance.data.get(
+                "reuse_last_version", False
+            )
+
             # Pass on 'review' family
             if "review" in aov_instance_data["families"]:
                 aov_instance.data["families"].append("review")

--- a/client/ayon_max/plugins/publish/collect_render_local.py
+++ b/client/ayon_max/plugins/publish/collect_render_local.py
@@ -78,9 +78,8 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
             aov_instance.data.update(aov_instance_data)
             aov_instance.data["families"] = [f"render.{render_target}"]
 
-            # The hasExplicitFrames flag controls whether frame indices are renumbered.
-            # Setting this to True ensures the published frames keep their original numbering
-            # and are not shifted during integration with the AYON server.
+            # The hasExplicitFrames flag would ensure the preset frame ranges are
+            # preserved and not renumbered to consecutive frame ranges on publish.
             aov_instance.data["hasExplicitFrames"] = True
 
             # Pass on 'review' family

--- a/client/ayon_max/plugins/publish/extract_render.py
+++ b/client/ayon_max/plugins/publish/extract_render.py
@@ -40,7 +40,6 @@ class ExtractLocalRender(publish.Extractor):
             for frame in instance.data["expectedFrameRange"]:
                 _, cancelled = rt.render(
                     frame=frame,
-                    vfb=False,
                     camera=camera_node,
                     cancelled=pymxs.byref(None)
                 )

--- a/client/ayon_max/plugins/publish/extract_render.py
+++ b/client/ayon_max/plugins/publish/extract_render.py
@@ -36,7 +36,7 @@ class ExtractLocalRender(publish.Extractor):
 
             was_cancelled = rt.Name('wasCancelled')
             was_cancelled.value = False
-            for frame in instance.data.get("expectedFrameRange", []):
+            for frame in instance.data["expectedFrameRange"]:
                 rt.render(
                     frame=frame,
                     vfb=False,
@@ -47,7 +47,7 @@ class ExtractLocalRender(publish.Extractor):
                     self.log.warning(f"Render cancelled at frame {frame}.")
                     break
 
-                self.log.debug("Local render extraction completed.")
+            self.log.debug("Local render extraction completed.")
         else:
             self.log.debug(
                 "Local render extraction for multi-camera is already "

--- a/client/ayon_max/plugins/publish/extract_render.py
+++ b/client/ayon_max/plugins/publish/extract_render.py
@@ -37,8 +37,6 @@ class ExtractLocalRender(publish.Extractor):
                 if camera else rt.viewport.GetCamera()
             )
 
-            was_cancelled = rt.Name('wasCancelled')
-            was_cancelled.value = False
             for frame in instance.data["expectedFrameRange"]:
                 _, cancelled = rt.render(
                     frame=frame,

--- a/client/ayon_max/plugins/publish/extract_render.py
+++ b/client/ayon_max/plugins/publish/extract_render.py
@@ -40,6 +40,7 @@ class ExtractLocalRender(publish.Extractor):
             for frame in instance.data["expectedFrameRange"]:
                 _, cancelled = rt.render(
                     frame=frame,
+                    vfb=False,
                     camera=camera_node,
                     cancelled=pymxs.byref(None)
                 )

--- a/client/ayon_max/plugins/publish/extract_render.py
+++ b/client/ayon_max/plugins/publish/extract_render.py
@@ -34,8 +34,19 @@ class ExtractLocalRender(publish.Extractor):
                 if camera else rt.viewport.GetCamera()
             )
 
-            for frame in range(int(rt.rendStart), int(rt.rendEnd) + 1):
-                rt.render(frame=frame, vfb=False, camera=camera_node)
+            wasCancelled = rt.Name('wasCancelled')
+            wasCancelled.value = False
+            for frame in instance.data.get("expectedFrameRange", []):
+                rt.render(
+                    frame=frame,
+                    vfb=False,
+                    camera=camera_node,
+                    cancelled=wasCancelled
+                )
+                if wasCancelled.value:
+                    self.log.warning(f"Render cancelled at frame {frame}.")
+                    break
+
                 self.log.debug("Local render extraction completed.")
         else:
             self.log.debug(

--- a/client/ayon_max/plugins/publish/extract_render.py
+++ b/client/ayon_max/plugins/publish/extract_render.py
@@ -34,16 +34,16 @@ class ExtractLocalRender(publish.Extractor):
                 if camera else rt.viewport.GetCamera()
             )
 
-            wasCancelled = rt.Name('wasCancelled')
-            wasCancelled.value = False
+            was_cancelled = rt.Name('wasCancelled')
+            was_cancelled.value = False
             for frame in instance.data.get("expectedFrameRange", []):
                 rt.render(
                     frame=frame,
                     vfb=False,
                     camera=camera_node,
-                    cancelled=wasCancelled
+                    cancelled=was_cancelled
                 )
-                if wasCancelled.value:
+                if was_cancelled.value:
                     self.log.warning(f"Render cancelled at frame {frame}.")
                     break
 

--- a/client/ayon_max/plugins/publish/extract_render.py
+++ b/client/ayon_max/plugins/publish/extract_render.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import os
 from ayon_core.pipeline import publish
 from ayon_core.pipeline.publish import KnownPublishError
 
@@ -36,13 +38,19 @@ class ExtractLocalRender(publish.Extractor):
                 rt.getNodeByName(camera)
                 if camera else rt.viewport.GetCamera()
             )
-
+            kwargs = {
+                "camera_node": camera_node,
+                "cancelled": pymxs.byref(None),
+                "vfb": False,
+            }
             for frame in instance.data["expectedFrameRange"]:
+                if instance.data["renderer"].startswith("Arnold"):
+                    filename, ext = os.path.splitext(rt.rendOutputFilename)
+                    new_output = f"{filename}{frame:04d}{ext}"
+                    kwargs["outputFile"] = new_output
                 _, cancelled = rt.render(
                     frame=frame,
-                    vfb=False,
-                    camera=camera_node,
-                    cancelled=pymxs.byref(None)
+                    **kwargs
                 )
                 if cancelled:
                     raise KnownPublishError(f"Render cancelled at frame {frame}.")

--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -496,12 +496,12 @@ class ValidateArnoldRenderSetting(ValidateGenericRenderSetting):
             if not path:
                 path = reset_rendersetting(instance, project_settings)
                 render_dir = os.path.dirname(path)
-        aov_manager.outputPath = path
         filename = os.path.basename(path)
         rt.rendOutputFilename = build_general_output_filename(
             render_dir,
             filename,
         )
+        aov_manager.outputPath = os.path.dirname(rt.rendOutputFilename)
         driver = aov_manager.drivers[0]
         driver.multipart = get_multipass_setting(
             renderer_name,


### PR DESCRIPTION
## Changelog Description
This PR is to add custom frame range support for local rendering.
Resolve https://github.com/ynput/ayon-3dsmax/issues/131

## Additional review information
Tested with the twin PR in ayon-core: https://github.com/ynput/ayon-core/pull/1818 and ayon-deadline: https://github.com/ynput/ayon-deadline/pull/252.

## Testing notes:
1. Create Render
2. Tested with local and farm rendering (with/without the custom frame range)
3. Should be working