### PR TITLE
Cancel callback for local rendering 

### DIFF
--- a/client/ayon_max/plugins/publish/extract_render.py
+++ b/client/ayon_max/plugins/publish/extract_render.py
@@ -3,7 +3,9 @@ from ayon_core.pipeline import publish
 
 
 try:
+    import pymxs
     from pymxs import runtime as rt
+
 except ImportError:
     rt = None
 
@@ -35,7 +37,16 @@ class ExtractLocalRender(publish.Extractor):
             )
 
             for frame in range(int(rt.rendStart), int(rt.rendEnd) + 1):
-                rt.render(frame=frame, vfb=False, camera=camera_node)
+                _, cancelled = rt.render(
+                    frame=frame,
+                    vfb=False,
+                    camera=camera_node,
+                    cancelled=pymxs.byref(None)
+                )
+                if cancelled:
+                    self.log.warning(f"Render cancelled at frame {frame}.")
+                    break
+
                 self.log.debug("Local render extraction completed.")
         else:
             self.log.debug(

--- a/client/ayon_max/plugins/publish/extract_render.py
+++ b/client/ayon_max/plugins/publish/extract_render.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from ayon_core.pipeline import publish
+from ayon_core.pipeline.publish import KnownPublishError
 
 
 try:
@@ -44,8 +45,7 @@ class ExtractLocalRender(publish.Extractor):
                     cancelled=pymxs.byref(None)
                 )
                 if cancelled:
-                    self.log.warning(f"Render cancelled at frame {frame}.")
-                    break
+                    raise KnownPublishError(f"Render cancelled at frame {frame}.")
 
                 self.log.debug("Local render extraction completed.")
         else:


### PR DESCRIPTION
## Changelog Description
This PR is to add the missing cancel callback for local rendering. When users hit esc to terminate rendering, it would raise KnownPublishError and exceptions to inform users about that and stop the rendering.
Resolve https://github.com/ynput/ayon-3dsmax/issues/133

## Additional review information
n/a

## Testing notes:
1. Publish render with local rendering
2. After rendering some frames, hit esc in your keyboard to terminate rendering
3. The publisher would raise Known Publish Error instead of continuing the new render.
