### PR TITLE
Validate Render Setting: Add missing repair action for general render output

### DIFF
--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -743,6 +743,17 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
                 image_format,
                 instance,
             )
+        else:
+            render_output = rt.rendOutputFilename
+            render_dir = set_correct_workfile_name_for_render_output(
+                instance,
+                os.path.dirname(render_output),
+            )
+            filename = os.path.basename(render_output)
+            rt.rendOutputFilename = build_general_output_filename(
+                render_dir,
+                filename,
+            )
 
     @classmethod
     def _repair_vray_output_filename(


### PR DESCRIPTION
## Changelog Description
This PR is to add the missing repair action for validate rendersettings to fix general render output.
Resolve https://github.com/ynput/ayon-3dsmax/issues/136

## Additional review information
Please test and see if it is errored out during farm submission, If yes we need to make separate PR(and issue) to fix the expected_file.

## Testing notes:
1. Set your image format to png in `ayon+settings://max/RenderSettings/image_format`
2. Disable your vray multipass setting to `ayon+settings://max/RenderSettings/vray_render_settings/separate_render_channels` 
3. Launch Max with the existing render instance
4. Publish
5. Validation block
6. Fix it
7. Publish successfully
