### PR TITLE
Model: Alembic export should validate UV correctly

### DIFF
--- a/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
+++ b/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
@@ -14,8 +14,12 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
 
     """Validate the current mesh has UVs.
 
-    This validator only checks if the mesh has UVW modifier to ensure
-    that UVs are present.
+    This validator only checks if the mesh has UVs but not
+    whether all the individual faces of the mesh have UVs.
+
+    It validates whether the current mesh has texture vertices.
+    If the mesh does not have texture vertices, it does not
+    have UVs in Max.
 
     """
 
@@ -27,22 +31,16 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
     optional = True
 
     settings_category = "max"
-    allowed_uv_classes = {
-        rt.Uvwmap,
-        rt.UVW_Xform,
-        rt.UVW_Mapping_Add,
-        rt.UVW_Mapping_Clear,
-        rt.UVW_Mapping_Paste,
-        rt.Unwrap_UVW
-    }
 
     @classmethod
     def get_invalid(cls, instance):
-        invalid = []
-        for member in instance.data["members"]:
-            for modifier in member.modifiers:
-                if rt.superClassOf(modifier) not in cls.allowed_uv_classes:
-                    invalid.append(member)
+        meshes = [member for member in instance.data["members"]
+                  if rt.isProperty(member, "mesh")]
+        invalid = [
+            member for member in meshes
+            if rt.isProperty(member.mesh, "numTVerts")
+            and member.mesh.numTVerts == 0
+        ]
         return invalid
 
     def process(self, instance):
@@ -63,6 +61,5 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
                 report,
                 description=(
                 "Model meshes are required to have UVs.\n\n"
-                "Meshes detected with no texture vertice or missing UVs"
-                "Make sure your mesh has UVs and that the UVW modifier is applied to the mesh."),
+                "Meshes detected with no texture vertice or missing UVs"),
                 title="Non-mesh objects found or mesh has missing UVs")

--- a/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
+++ b/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
@@ -38,8 +38,7 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
                   if rt.isProperty(member, "mesh")]
         invalid = [
             member for member in meshes
-            if rt.isProperty(member.mesh, "numTVerts")
-            and member.mesh.numTVerts == 0
+            if not rt.isProperty(member.mesh, "numTVerts")
         ]
         return invalid
 

--- a/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
+++ b/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
@@ -14,8 +14,12 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
 
     """Validate the current mesh has UVs.
 
-    This validator only checks if the mesh has UVW modifier to ensure
-    that UVs are present.
+    This validator only checks if the mesh has UVs but not
+    whether all the individual faces of the mesh have UVs.
+
+    It validates whether the current mesh has texture vertices.
+    If the mesh does not have texture vertices, it does not
+    have UVs in Max.
 
     """
 
@@ -27,22 +31,15 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
     optional = True
 
     settings_category = "max"
-    allowed_uv_classes = {
-        rt.Uvwmap,
-        rt.UVW_Xform,
-        rt.UVW_Mapping_Add,
-        rt.UVW_Mapping_Clear,
-        rt.UVW_Mapping_Paste,
-        rt.Unwrap_UVW
-    }
 
     @classmethod
     def get_invalid(cls, instance):
-        invalid = []
-        for member in instance.data["members"]:
-            for modifier in member.modifiers:
-                if rt.superClassOf(modifier) not in cls.allowed_uv_classes:
-                    invalid.append(member)
+        meshes = [member for member in instance.data["members"]
+                  if rt.isProperty(member, "mesh")]
+        invalid = [
+            member for member in meshes
+            if rt.meshop.getNumMaps(member.mesh) == 0
+        ]
         return invalid
 
     def process(self, instance):
@@ -63,6 +60,5 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
                 report,
                 description=(
                 "Model meshes are required to have UVs.\n\n"
-                "Meshes detected with no texture vertice or missing UVs"
-                "Make sure your mesh has UVs and that the UVW modifier is applied to the mesh."),
+                "Meshes detected with no texture vertice or missing UVs"),
                 title="Non-mesh objects found or mesh has missing UVs")

--- a/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
+++ b/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
@@ -38,7 +38,8 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
                   if rt.isProperty(member, "mesh")]
         invalid = [
             member for member in meshes
-            if not rt.isProperty(member.mesh, "numTVerts")
+            if rt.isProperty(member.mesh, "numTVerts")
+            and member.mesh.numTVerts == 0
         ]
         return invalid
 

--- a/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
+++ b/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
@@ -36,8 +36,10 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
     def get_invalid(cls, instance):
         meshes = [member for member in instance.data["members"]
                   if rt.isProperty(member, "mesh")]
-        invalid = [member for member in meshes
-                   if member.mesh.numTVerts == 0]
+        invalid = [
+            member for member in meshes
+            if rt.meshop.getNumMaps(member.mesh) == 0
+        ]
         return invalid
 
     def process(self, instance):

--- a/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
+++ b/client/ayon_max/plugins/publish/validate_mesh_has_uv.py
@@ -14,12 +14,8 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
 
     """Validate the current mesh has UVs.
 
-    This validator only checks if the mesh has UVs but not
-    whether all the individual faces of the mesh have UVs.
-
-    It validates whether the current mesh has texture vertices.
-    If the mesh does not have texture vertices, it does not
-    have UVs in Max.
+    This validator only checks if the mesh has UVW modifier to ensure
+    that UVs are present.
 
     """
 
@@ -31,15 +27,22 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
     optional = True
 
     settings_category = "max"
+    allowed_uv_classes = {
+        rt.Uvwmap,
+        rt.UVW_Xform,
+        rt.UVW_Mapping_Add,
+        rt.UVW_Mapping_Clear,
+        rt.UVW_Mapping_Paste,
+        rt.Unwrap_UVW
+    }
 
     @classmethod
     def get_invalid(cls, instance):
-        meshes = [member for member in instance.data["members"]
-                  if rt.isProperty(member, "mesh")]
-        invalid = [
-            member for member in meshes
-            if rt.meshop.getNumMaps(member.mesh) == 0
-        ]
+        invalid = []
+        for member in instance.data["members"]:
+            for modifier in member.modifiers:
+                if rt.superClassOf(modifier) not in cls.allowed_uv_classes:
+                    invalid.append(member)
         return invalid
 
     def process(self, instance):
@@ -60,5 +63,6 @@ class ValidateMeshHasUVs(pyblish.api.InstancePlugin,
                 report,
                 description=(
                 "Model meshes are required to have UVs.\n\n"
-                "Meshes detected with no texture vertice or missing UVs"),
+                "Meshes detected with no texture vertice or missing UVs"
+                "Make sure your mesh has UVs and that the UVW modifier is applied to the mesh."),
                 title="Non-mesh objects found or mesh has missing UVs")


### PR DESCRIPTION
## Changelog Description
This PR is to fix the bug on the validator for uv maps when checking on invalid objects.
Resolve https://github.com/ynput/ayon-3dsmax/issues/135

## Additional review information
n/a

## Testing notes:
1. Create Model with/without UV(aka with or without UVW modifier)
2. Publish
3. Validation should block when there is no uv map while passing when it is with UV.