### PR TITLE
Redshift: Cryptomatte integrated for AYON publish respecting to RenderSettings 

### DIFF
--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -317,7 +317,11 @@ class RenderProducts(object):
         # get render elements from the renders
         for index in range(render_elem_num):
             renderlayer = render_elem.GetRenderElement(index)
-            if renderlayer.enabled:
+            if self.get_render_element_by_multipass(
+                renderer_name,
+                renderlayer,
+                is_multipass,
+            ):
                 renderpass = str(renderlayer.elementname)
                 renderlayer_filepath = self.get_render_element_outputfilename(
                     renderer,
@@ -337,6 +341,28 @@ class RenderProducts(object):
                 expected_elements.append((render_element, str(filepath)))
 
         return expected_elements
+
+    def get_render_element_by_multipass(
+            self,
+            renderer_name: str,
+            renderlayer: Any,
+            multipass: bool
+    ) -> bool:
+        """Get render element name based on multipass setting.
+
+        Args:
+            renderer_name (str): The name of the renderer.
+            renderlayer (Any, rt.RenderTarget): The render layer instance.
+            multipass (bool): Whether multipass is enabled.
+
+        Returns:
+            bool: True if the render element should be included
+                based on the multipass setting, False otherwise.
+        """
+        if renderer_name == "Default_Scanline_Renderer":
+            return renderlayer.enabled
+
+        return multipass and renderlayer.enabled
 
     def _get_vray_additional_outputs(self, renderer: Any, is_multipass: bool) -> list[str]:
         """Get additional V-Ray outputs like Alpha and RGB_color.

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -361,15 +361,13 @@ class RenderProducts(object):
         if renderer_name == "Default_Scanline_Renderer":
             return renderlayer.enabled
 
-        if multipass:
-            return renderlayer.enabled
+        cryptomatte_enabled = self.has_cryptomatte_enabled(renderer_name, image_format)
+        is_cryptomatte_layer = "Cryptomatte" in renderlayer.elementname
 
-        if self.has_cryptomatte_enabled(renderer_name, image_format):
-            if "Cryptomatte" in renderlayer.elementname:
-                return renderlayer.enabled
-            return False
+        if cryptomatte_enabled:
+            return renderlayer.enabled if is_cryptomatte_layer else False
 
-        return False
+        return renderlayer.enabled if multipass else False
 
     def _get_vray_additional_outputs(self, renderer: Any, is_multipass: bool) -> list[str]:
         """Get additional V-Ray outputs like Alpha and RGB_color.

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -362,11 +362,11 @@ class RenderProducts(object):
             return renderlayer.enabled
 
         if multipass:
-            if renderer_name == "Redshift_Renderer" and image_format == "exr":
-                if "Cryptomatte" in renderlayer.elementname:
-                    return renderlayer.enabled
-                return False
             return renderlayer.enabled
+
+        if self.has_cryptomatte_enabled(renderer_name, image_format):
+            if "Cryptomatte" in renderlayer.elementname:
+                return renderlayer.enabled
 
         return False
 
@@ -411,3 +411,26 @@ class RenderProducts(object):
             str: The image format of the render output.
         """
         return self._project_settings["max"]["RenderSettings"]["image_format"]  # noqa
+
+    def has_cryptomatte_enabled(self, renderer_name: str, image_format: str) -> bool:
+        """Check if Cryptomatte is enabled for the given renderer and image format.
+
+        Args:
+            renderer_name (str): renderer name (e.g., "Redshift_Renderer")
+            image_format (str): image format of the render output (e.g., "exr")
+
+        Returns:
+            bool: True if Cryptomatte is enabled for the given renderer and
+                image format, False otherwise.
+        """
+        cryptomatte_enabled = (
+            self._project_settings["max"]
+                                  ["RenderSettings"]
+                                  ["redshift_render_settings"]
+                                  ["cryptomatte_enabled"]
+        )
+        return (
+            renderer_name == "Redshift_Renderer"
+            and image_format == "exr"
+            and cryptomatte_enabled
+        )

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -317,9 +317,7 @@ class RenderProducts(object):
         # get render elements from the renders
         for index in range(render_elem_num):
             renderlayer = render_elem.GetRenderElement(index)
-            if self.get_render_element_by_multipass(
-                renderer_name, renderlayer, is_multipass, image_format
-            ):
+            if renderlayer.enabled:
                 renderpass = str(renderlayer.elementname)
                 renderlayer_filepath = self.get_render_element_outputfilename(
                     renderer,
@@ -339,35 +337,6 @@ class RenderProducts(object):
                 expected_elements.append((render_element, str(filepath)))
 
         return expected_elements
-
-    def get_render_element_by_multipass(
-            self,
-            renderer_name: str,
-            renderlayer: Any,
-            multipass: bool,
-            image_format: str) -> bool:
-        """Get render element name based on multipass setting.
-
-        Args:
-            renderer_name (str): The name of the renderer.
-            renderlayer (Any, rt.RenderTarget): The render layer instance.
-            multipass (bool): Whether multipass is enabled.
-            image_format (str): The image format of the render output.
-
-        Returns:
-            bool: True if the render element should be included
-                based on the multipass setting, False otherwise.
-        """
-        if renderer_name == "Default_Scanline_Renderer":
-            return renderlayer.enabled
-
-        cryptomatte_enabled = self.has_cryptomatte_enabled(renderer_name, image_format)
-        is_cryptomatte_layer = "Cryptomatte" in renderlayer.elementname
-
-        if cryptomatte_enabled:
-            return renderlayer.enabled if is_cryptomatte_layer else False
-
-        return renderlayer.enabled if multipass else False
 
     def _get_vray_additional_outputs(self, renderer: Any, is_multipass: bool) -> list[str]:
         """Get additional V-Ray outputs like Alpha and RGB_color.
@@ -410,26 +379,3 @@ class RenderProducts(object):
             str: The image format of the render output.
         """
         return self._project_settings["max"]["RenderSettings"]["image_format"]  # noqa
-
-    def has_cryptomatte_enabled(self, renderer_name: str, image_format: str) -> bool:
-        """Check if Cryptomatte is enabled for the given renderer and image format.
-
-        Args:
-            renderer_name (str): renderer name (e.g., "Redshift_Renderer")
-            image_format (str): image format of the render output (e.g., "exr")
-
-        Returns:
-            bool: True if Cryptomatte is enabled for the given renderer and
-                image format, False otherwise.
-        """
-        cryptomatte_enabled = (
-            self._project_settings["max"]
-                                  ["RenderSettings"]
-                                  ["redshift_render_settings"]
-                                  ["cryptomatte_enabled"]
-        )
-        return (
-            renderer_name == "Redshift_Renderer"
-            and image_format == "exr"
-            and cryptomatte_enabled
-        )

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -367,6 +367,7 @@ class RenderProducts(object):
         if self.has_cryptomatte_enabled(renderer_name, image_format):
             if "Cryptomatte" in renderlayer.elementname:
                 return renderlayer.enabled
+            return False
 
         return False
 

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -365,7 +365,7 @@ class RenderProducts(object):
             if "Cryptomatte" in renderlayer.elementname:
                 return renderlayer.enabled
 
-        return renderlayer.enabled if multipass else False
+        return renderlayer.enabled and multipass
 
     def _get_vray_additional_outputs(self, renderer: Any, is_multipass: bool) -> list[str]:
         """Get additional V-Ray outputs like Alpha and RGB_color.

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -318,9 +318,7 @@ class RenderProducts(object):
         for index in range(render_elem_num):
             renderlayer = render_elem.GetRenderElement(index)
             if self.get_render_element_by_multipass(
-                renderer_name,
-                renderlayer,
-                is_multipass,
+                renderer_name, renderlayer, is_multipass, image_format
             ):
                 renderpass = str(renderlayer.elementname)
                 renderlayer_filepath = self.get_render_element_outputfilename(
@@ -346,14 +344,15 @@ class RenderProducts(object):
             self,
             renderer_name: str,
             renderlayer: Any,
-            multipass: bool
-    ) -> bool:
+            multipass: bool,
+            image_format: str) -> bool:
         """Get render element name based on multipass setting.
 
         Args:
             renderer_name (str): The name of the renderer.
             renderlayer (Any, rt.RenderTarget): The render layer instance.
             multipass (bool): Whether multipass is enabled.
+            image_format (str): The image format of the render output.
 
         Returns:
             bool: True if the render element should be included
@@ -362,7 +361,11 @@ class RenderProducts(object):
         if renderer_name == "Default_Scanline_Renderer":
             return renderlayer.enabled
 
-        return multipass and renderlayer.enabled
+        if renderer_name == "Redshift_Renderer" and image_format == "exr":
+            if "Cryptomatte" in renderlayer.elementname:
+                return renderlayer.enabled
+
+        return renderlayer.enabled if multipass else False
 
     def _get_vray_additional_outputs(self, renderer: Any, is_multipass: bool) -> list[str]:
         """Get additional V-Ray outputs like Alpha and RGB_color.

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -361,6 +361,9 @@ class RenderProducts(object):
         if renderer_name == "Default_Scanline_Renderer":
             return renderlayer.enabled
 
+        # If cryptomatte render element is enabled in Redshift it will
+        # always write it out as a separate file, regardless of whether
+        # 'separate AOVs' is enabled or not
         if renderer_name == "Redshift_Renderer" and image_format == "exr":
             if "Cryptomatte" in renderlayer.elementname:
                 return renderlayer.enabled

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -33,9 +33,6 @@ class RedshiftSettingsModel(BaseSettingsModel):
     separate_aov_files: bool = SettingsField(
         title="Separate AOV Files"
     )
-    cryptomatte_enabled: bool = SettingsField(
-        title="Enable Cryptomatte for AYON Publish"
-    )
 
 
 class RenderSettingsModel(BaseSettingsModel):
@@ -67,7 +64,6 @@ DEFAULT_RENDER_SETTINGS = {
         "separate_render_channels": True
     },
     "redshift_render_settings": {
-        "separate_aov_files": True,
-        "cryptomatte_enabled": False,
+        "separate_aov_files": True
     }
 }

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -34,7 +34,7 @@ class RedshiftSettingsModel(BaseSettingsModel):
         title="Separate AOV Files"
     )
     cryptomatte_enabled: bool = SettingsField(
-        title="Cryptomatte AOVs enabled"
+        title="Enable Cryptomatte for AYON Publish"
     )
 
 

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -33,6 +33,9 @@ class RedshiftSettingsModel(BaseSettingsModel):
     separate_aov_files: bool = SettingsField(
         title="Separate AOV Files"
     )
+    cryptomatte_enabled: bool = SettingsField(
+        title="Cryptomatte AOVs enabled"
+    )
 
 
 class RenderSettingsModel(BaseSettingsModel):
@@ -64,6 +67,7 @@ DEFAULT_RENDER_SETTINGS = {
         "separate_render_channels": True
     },
     "redshift_render_settings": {
-        "separate_aov_files": True
+        "separate_aov_files": True,
+        "cryptomatte_enabled": False,
     }
 }


### PR DESCRIPTION
## Changelog Description
This PR is to make sure cryptomatte integrated for AYON publish respecting to Render Settings in 3dsmax. Users can decide whether they want to include Cryptomatte from the render settings.

## Additional review information
Fixes: https://github.com/ynput/ayon-3dsmax/issues/141

## Testing notes:
1. Toggle on/off with `ayon+settings://max/RenderSettings/redshift_render_settings/separate_aov_files` and  cryptomatte is on in render_settings from Max
2.  Publish render instance 
3. Cryptomatte won't be published when cryptomatte is off in render_settings from Max
while it will be published as soon as the toggle is on.
