### PR TITLE
Allow more user customization for 3dsmax render folder

### DIFF
--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -33,9 +33,11 @@ from ayon_core.style import load_stylesheet
 
 try:
     from pymxs import runtime as rt
+    import pymxs
 
 except ImportError:
     rt = None
+    pymxs = None
 
 
 JSON_PREFIX = "JSON::"
@@ -206,11 +208,11 @@ def get_current_renderer():
     return rt.renderers.production
 
 
-def get_work_default_directory(data: dict) -> str:
+def get_work_default_directory(data: Dict) -> str:
     """Helping function for formatting of anatomy paths
 
     Arguments:
-        data (dict): dictionary with attributes used for formatting
+        data (Dict): dictionary with attributes used for formatting
 
     Returns:
         str: path to the default work directory for current context
@@ -250,16 +252,43 @@ def get_work_default_directory(data: dict) -> str:
     })
 
     work_default_dir_template = anatomy.get_template_item("work", "default", "directory")
-    normalized_dir = work_default_dir_template.format_strict(data).normalized()
+    clean_data = sanitize_data_for_path(data)
+    normalized_dir = work_default_dir_template.format_strict(clean_data).normalized()
     return str(normalized_dir).replace("\\", "/")
 
 
-def get_default_render_folder(data: dict, project_setting: dict=None) -> str:
+def sanitize_data_for_path(data: Dict) -> Dict:
+    """Remove or convert pymxs objects from data dict
+
+    Args:
+        data (Dict): Dictionary containing data to be sanitized.
+
+    Returns:
+        Dict: Sanitized dictionary with pymxs objects converted to strings.
+    """
+    sanitized = {}
+    for key, value in data.items():
+        if isinstance(value, pymxs.MXSWrapperBase):
+            # Convert to string or skip
+            sanitized[key] = str(value) if value else ""
+        elif isinstance(value, dict):
+            sanitized[key] = sanitize_data_for_path(value)
+        elif isinstance(value, list):
+            sanitized[key] = [
+                str(val) if isinstance(val, pymxs.MXSWrapperBase) else val
+                for val in value
+            ]
+        else:
+            sanitized[key] = value
+    return sanitized
+
+
+def get_default_render_folder(data: Dict, project_setting: Dict=None) -> str:
     """Get the default render folder path for current context based on project settings
 
     Args:
-        data (dict): template data
-        project_setting (dict, optional): project settings. Defaults to None.
+        data (Dict): template data
+        project_setting (Dict, optional): project settings. Defaults to None.
 
     Returns:
         str: The default render folder path.

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Library of functions useful for 3dsmax pipeline."""
 import os
-import copy
 import contextlib
 import logging
 import json
@@ -34,15 +33,38 @@ from ayon_core.style import load_stylesheet
 
 try:
     from pymxs import runtime as rt
-    import pymxs
 
 except ImportError:
     rt = None
-    pymxs = None
 
 
 JSON_PREFIX = "JSON::"
 log = logging.getLogger("ayon_max")
+
+
+def _sanitize_template_data(value: Any) -> Any:
+    """Function to sanitize template data to avoid
+    pickle issue from QMainWindow or Max Objects
+
+    Args:
+        value (Any): Any type of value to sanitize
+
+    Returns:
+        Any: Sanitized value
+    """
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_template_data(sub_value)
+            for key, sub_value in value.items()
+        }
+
+    if isinstance(value, (list, tuple, set)):
+        return [_sanitize_template_data(item) for item in value]
+
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+
+    return str(value)
 
 
 def get_main_window():
@@ -251,46 +273,9 @@ def get_work_default_directory(data: Dict) -> str:
             "basetype": product_base_type,
         },
     })
-
     work_default_dir_template = anatomy.get_template_item("work", "default", "directory")
-    clean_data = sanitize_data_for_path(data)
-    normalized_dir = work_default_dir_template.format_strict(clean_data).normalized()
+    normalized_dir = work_default_dir_template.format_strict(data).normalized()
     return str(normalized_dir).replace("\\", "/")
-
-
-def sanitize_data_for_path(data: Dict) -> Dict:
-    """Remove or convert pymxs objects from data dict
-
-    Args:
-        data (Dict): Dictionary containing data to be sanitized.
-
-    Returns:
-        Dict: Sanitized dictionary with pymxs objects converted to strings.
-    """
-    sanitized = {}
-    mxs_wrapper_base = getattr(pymxs, "MXSWrapperBase", None)
-
-    for key, value in data.items():
-        if mxs_wrapper_base and isinstance(value, mxs_wrapper_base):
-            # Convert to string or skip
-            sanitized[key] = str(value) if value else ""
-        elif isinstance(value, dict):
-            sanitized[key] = sanitize_data_for_path(value)
-        elif isinstance(value, list):
-            sanitized[key] = [
-                sanitize_data_for_path(val) if isinstance(val, dict)
-                else (
-                    str(val)
-                    if (mxs_wrapper_base and isinstance(val, mxs_wrapper_base))
-                    else val
-                )
-                for val in value
-            ]
-        else:
-            sanitized[key] = value
-
-    return sanitized
-
 
 def get_default_render_folder(
     data: Dict,
@@ -305,15 +290,23 @@ def get_default_render_folder(
     Returns:
         str: The default render folder path.
     """
-    render_data = copy.deepcopy(data)
+    render_data = _sanitize_template_data(dict(data))
     if project_setting is None:
         project_name = get_current_project_name()
         project_setting = get_project_settings(project_name)
 
     render_data["work"] = get_work_default_directory(render_data)
+    print(render_data)
     render_folder = project_setting["max"]["RenderSettings"]["default_render_image_folder"]
     formatted_render_folder = StringTemplate(render_folder).format(render_data)
-    return os.path.normpath(os.path.join(render_data["work"], formatted_render_folder))
+    normalized_render_folder = os.path.normpath(formatted_render_folder)
+
+    if os.path.isabs(normalized_render_folder):
+        return normalized_render_folder.replace("\\", "/")
+
+    return os.path.normpath(
+        os.path.join(render_data["work"], normalized_render_folder)
+    ).replace("\\", "/")
 
 
 def get_vray_settings(renderer_name: str, renderer: Any) -> Any:

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -253,12 +253,12 @@ def get_work_default_directory(data: dict) -> str:
     return str(normalized_dir).replace("\\", "/")
 
 
-def get_default_render_folder(project_setting: dict=None, data: dict=None) -> str:
+def get_default_render_folder(data: dict, project_setting: dict=None) -> str:
     """_summary_
 
     Args:
+        data (dict): template data
         project_setting (dict, optional): project settings. Defaults to None.
-        data (dict, optional): template data. Defaults to None.
 
     Returns:
         str: The default render folder path.
@@ -269,11 +269,6 @@ def get_default_render_folder(project_setting: dict=None, data: dict=None) -> st
                                     ["RenderSettings"]
                                     ["default_render_image_folder"])
     return StringTemplate(render_folder).format(template_data)
-
-
-def get_expected_render_folder(setting, filename):
-    render_folder = get_default_render_folder(setting)
-    return os.path.join(render_folder, filename)
 
 
 def get_vray_settings(renderer_name: str, renderer: Any) -> Any:
@@ -1068,7 +1063,7 @@ def set_correct_workfile_name_for_render_output(
     """
     project_settings = instance.context.data["project_settings"]
     render_root = os.path.normpath(
-        get_default_render_folder(project_settings)
+        get_default_render_folder(instance.data, project_settings)
     )
     normalized_path = os.path.normpath(filepath)
 

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -267,19 +267,27 @@ def sanitize_data_for_path(data: Dict) -> Dict:
         Dict: Sanitized dictionary with pymxs objects converted to strings.
     """
     sanitized = {}
+    mxs_wrapper_base = getattr(pymxs, "MXSWrapperBase", None)
+
     for key, value in data.items():
-        if isinstance(value, pymxs.MXSWrapperBase):
+        if mxs_wrapper_base and isinstance(value, mxs_wrapper_base):
             # Convert to string or skip
             sanitized[key] = str(value) if value else ""
         elif isinstance(value, dict):
             sanitized[key] = sanitize_data_for_path(value)
         elif isinstance(value, list):
             sanitized[key] = [
-                str(val) if isinstance(val, pymxs.MXSWrapperBase) else val
+                sanitize_data_for_path(val) if isinstance(val, dict)
+                else (
+                    str(val)
+                    if (mxs_wrapper_base and isinstance(val, mxs_wrapper_base))
+                    else val
+                )
                 for val in value
             ]
         else:
             sanitized[key] = value
+
     return sanitized
 
 

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -4,6 +4,7 @@ import os
 import contextlib
 import logging
 import json
+from pathlib import Path
 from functools import partial
 import pyblish.api
 import re
@@ -231,20 +232,22 @@ def get_current_renderer():
     return rt.renderers.production
 
 
-def get_work_default_directory(data: Dict) -> str:
+def get_work_default_directory(data: Dict) -> tuple[str, Dict]:
     """Helping function for formatting of anatomy paths
 
     Arguments:
         data (Dict): dictionary with attributes used for formatting
 
     Returns:
-        str: path to the default work directory for current context
+        tuple[str, Dict]:
+            - Path to the default work directory for current context.
+            - Sanitized template data used for formatting.
     """
 
     project_name = get_current_project_name()
     anatomy = Anatomy(project_name)
 
-    data = dict(data)
+    data = _sanitize_template_data(dict(data))
 
     version = data.get("version")
     if version is None:
@@ -299,14 +302,12 @@ def get_default_render_folder(
     render_data["work"], render_data = get_work_default_directory(render_data)
     render_folder = project_setting["max"]["RenderSettings"]["default_render_image_folder"]
     formatted_render_folder = StringTemplate(render_folder).format(render_data)
-    normalized_render_folder = os.path.normpath(formatted_render_folder)
+    normalized_render_folder = Path(formatted_render_folder)
 
-    if os.path.isabs(normalized_render_folder):
-        return normalized_render_folder.replace("\\", "/")
+    if normalized_render_folder.is_absolute():
+        return normalized_render_folder.as_posix()
 
-    return os.path.normpath(
-        os.path.join(render_data["work"], normalized_render_folder)
-    ).replace("\\", "/")
+    return (Path(render_data["work"]) / normalized_render_folder).as_posix()
 
 
 def get_vray_settings(renderer_name: str, renderer: Any) -> Any:

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -276,7 +276,7 @@ def get_work_default_directory(data: Dict) -> str:
     })
     work_default_dir_template = anatomy.get_template_item("work", "default", "directory")
     normalized_dir = work_default_dir_template.format_strict(data).normalized()
-    return str(normalized_dir).replace("\\", "/"), data
+    return str(normalized_dir), data
 
 def get_default_render_folder(
     data: Dict,

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -232,7 +232,7 @@ def get_current_renderer():
     return rt.renderers.production
 
 
-def get_work_default_directory(data: Dict) -> tuple[str, Dict]:
+def get_work_default_directory_and_data(data: Dict) -> tuple[str, Dict]:
     """Helping function for formatting of anatomy paths
 
     Arguments:
@@ -299,15 +299,12 @@ def get_default_render_folder(
         project_name = get_current_project_name()
         project_setting = get_project_settings(project_name)
 
-    render_data["work"], render_data = get_work_default_directory(render_data)
+    work_dir, render_data = get_work_default_directory_and_data(render_data)
+    render_data["work"] = work_dir
     render_folder = project_setting["max"]["RenderSettings"]["default_render_image_folder"]
     formatted_render_folder = StringTemplate(render_folder).format(render_data)
     normalized_render_folder = Path(formatted_render_folder)
-
-    if normalized_render_folder.is_absolute():
-        return normalized_render_folder.as_posix()
-
-    return (Path(render_data["work"]) / normalized_render_folder).as_posix()
+    return str(normalized_render_folder)
 
 
 def get_vray_settings(renderer_name: str, renderer: Any) -> Any:

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1114,7 +1114,7 @@ def set_correct_workfile_name_for_render_output(
     )
     match = re.match(pattern, normalized_path)
     if not match:
-        return filepath
+        return ""
 
     render_workfile_name = match.group("workfile")
     if render_workfile_name == current_workfile_filename:

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Library of functions useful for 3dsmax pipeline."""
 import os
+import copy
 import contextlib
 import logging
 import json
@@ -10,19 +11,23 @@ import re
 from typing import Any, Dict, Union
 
 from ayon_core.pipeline import (
+    Anatomy,
     get_current_project_name,
     get_current_folder_path,
     get_current_task_name,
+    get_current_host_name,
     colorspace,
     registered_host,
     AYON_INSTANCE_ID,
     AVALON_INSTANCE_ID,
 )
+from ayon_core.lib import StringTemplate, get_version_from_path
 from ayon_core.tools.utils import SimplePopup
 from ayon_core.settings import get_project_settings
 from ayon_core.pipeline.context_tools import (
     get_current_task_entity
 )
+from ayon_core.pipeline.template_data import get_template_data_with_names
 from ayon_core.pipeline.create import CreateContext
 from ayon_core.style import load_stylesheet
 
@@ -202,14 +207,68 @@ def get_current_renderer():
     return rt.renderers.production
 
 
-def get_default_render_folder(project_setting=None):
-    folder = rt.maxFilePath
-    # hard-coded, should be customized in the setting
-    folder = folder.replace("\\", "/")
+def get_work_default_directory(data: dict) -> str:
+    """Helping function for formatting of anatomy paths
+
+    Arguments:
+        data (dict): dictionary with attributes used for formatting
+
+    Returns:
+        str: path to the default work directory for current context
+    """
+
+    project_name = get_current_project_name()
+    anatomy = Anatomy(project_name)
+
+    version = data.get("version")
+    if version is None:
+        project_filename = rt.maxFileName
+        data["version"] = get_version_from_path(project_filename)
+
+    folder_path = data["folderPath"]
+    task_name = data["task"]
+    host_name = get_current_host_name()
+
+    context_data = get_template_data_with_names(
+        project_name, folder_path, task_name, host_name
+    )
+    data.update(context_data)
+    product_type = data["productType"]
+    product_base_type = data.get("productBaseType")
+    if not product_base_type:
+        product_base_type = product_type
+
+    data.update({
+        "subset": data["productName"],
+        "family": product_base_type,
+        "product": {
+            "name": data["productName"],
+            "type": product_type,
+            "basetype": product_base_type,
+        },
+    })
+
+    work_default_dir_template = anatomy.get_template_item("work", "default", "directory")
+    normalized_dir = work_default_dir_template.format_strict(data).normalized()
+    return str(normalized_dir).replace("\\", "/")
+
+
+def get_default_render_folder(project_setting: dict=None, data: dict=None) -> str:
+    """_summary_
+
+    Args:
+        project_setting (dict, optional): project settings. Defaults to None.
+        data (dict, optional): template data. Defaults to None.
+
+    Returns:
+        str: The default render folder path.
+    """
+    template_data = copy.deepcopy(data)
+    template_data["work"] = get_work_default_directory(template_data)
     render_folder = (project_setting["max"]
                                     ["RenderSettings"]
                                     ["default_render_image_folder"])
-    return os.path.join(folder, render_folder)
+    return StringTemplate(render_folder).format(template_data)
 
 
 def get_expected_render_folder(setting, filename):

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -219,6 +219,8 @@ def get_work_default_directory(data: dict) -> str:
     project_name = get_current_project_name()
     anatomy = Anatomy(project_name)
 
+    data = dict(data)
+
     version = data.get("version")
     if version is None:
         project_filename = rt.maxFileName
@@ -253,7 +255,7 @@ def get_work_default_directory(data: dict) -> str:
 
 
 def get_default_render_folder(data: dict, project_setting: dict=None) -> str:
-    """_summary_
+    """Get the default render folder path for current context based on project settings
 
     Args:
         data (dict): template data
@@ -262,11 +264,12 @@ def get_default_render_folder(data: dict, project_setting: dict=None) -> str:
     Returns:
         str: The default render folder path.
     """
-    data["work"] = get_work_default_directory(data)
+    render_data = dict(data)
+    render_data["work"] = get_work_default_directory(render_data)
     render_folder = (project_setting["max"]
                                     ["RenderSettings"]
                                     ["default_render_image_folder"])
-    return StringTemplate(render_folder).format(data)
+    return StringTemplate(render_folder).format(render_data)
 
 
 def get_vray_settings(renderer_name: str, renderer: Any) -> Any:
@@ -837,12 +840,13 @@ def get_view_node_from_sme_view(sme_view, view_node_name):
 
 
 def get_target_sme_view(target_view: int):
-    """_summary_
+    """Return a Slate Material Editor view by index.
 
     Args:
-        target_view (int): active SME view
+        target_view (int): Active SME view index.
+
     Returns:
-        IObject: SME View object
+        IObject: The requested SME view object.
     """
     return rt.sme.GetView(target_view)
 

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -265,6 +265,7 @@ def get_work_default_directory(data: Dict) -> str:
         product_base_type = product_type
 
     data.update({
+        "root": anatomy.roots,
         "subset": data["productName"],
         "family": product_base_type,
         "product": {
@@ -275,7 +276,7 @@ def get_work_default_directory(data: Dict) -> str:
     })
     work_default_dir_template = anatomy.get_template_item("work", "default", "directory")
     normalized_dir = work_default_dir_template.format_strict(data).normalized()
-    return str(normalized_dir).replace("\\", "/")
+    return str(normalized_dir).replace("\\", "/"), data
 
 def get_default_render_folder(
     data: Dict,
@@ -295,8 +296,7 @@ def get_default_render_folder(
         project_name = get_current_project_name()
         project_setting = get_project_settings(project_name)
 
-    render_data["work"] = get_work_default_directory(render_data)
-    print(render_data)
+    render_data["work"], render_data = get_work_default_directory(render_data)
     render_folder = project_setting["max"]["RenderSettings"]["default_render_image_folder"]
     formatted_render_folder = StringTemplate(render_folder).format(render_data)
     normalized_render_folder = os.path.normpath(formatted_render_folder)

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Library of functions useful for 3dsmax pipeline."""
 import os
-import copy
 import contextlib
 import logging
 import json
@@ -263,12 +262,11 @@ def get_default_render_folder(data: dict, project_setting: dict=None) -> str:
     Returns:
         str: The default render folder path.
     """
-    template_data = copy.deepcopy(data)
-    template_data["work"] = get_work_default_directory(template_data)
+    data["work"] = get_work_default_directory(data)
     render_folder = (project_setting["max"]
                                     ["RenderSettings"]
                                     ["default_render_image_folder"])
-    return StringTemplate(render_folder).format(template_data)
+    return StringTemplate(render_folder).format(data)
 
 
 def get_vray_settings(renderer_name: str, renderer: Any) -> Any:

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -304,6 +304,8 @@ def get_default_render_folder(
     render_folder = project_setting["max"]["RenderSettings"]["default_render_image_folder"]
     formatted_render_folder = StringTemplate(render_folder).format(render_data)
     normalized_render_folder = Path(formatted_render_folder)
+    if not normalized_render_folder.is_absolute():
+        normalized_render_folder = Path(work_dir) / normalized_render_folder
     return str(normalized_render_folder)
 
 

--- a/client/ayon_max/api/lib.py
+++ b/client/ayon_max/api/lib.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Library of functions useful for 3dsmax pipeline."""
 import os
+import copy
 import contextlib
 import logging
 import json
@@ -291,7 +292,10 @@ def sanitize_data_for_path(data: Dict) -> Dict:
     return sanitized
 
 
-def get_default_render_folder(data: Dict, project_setting: Dict=None) -> str:
+def get_default_render_folder(
+    data: Dict,
+    project_setting: Dict = None,
+) -> str:
     """Get the default render folder path for current context based on project settings
 
     Args:
@@ -301,12 +305,15 @@ def get_default_render_folder(data: Dict, project_setting: Dict=None) -> str:
     Returns:
         str: The default render folder path.
     """
-    render_data = dict(data)
+    render_data = copy.deepcopy(data)
+    if project_setting is None:
+        project_name = get_current_project_name()
+        project_setting = get_project_settings(project_name)
+
     render_data["work"] = get_work_default_directory(render_data)
-    render_folder = (project_setting["max"]
-                                    ["RenderSettings"]
-                                    ["default_render_image_folder"])
-    return StringTemplate(render_folder).format(render_data)
+    render_folder = project_setting["max"]["RenderSettings"]["default_render_image_folder"]
+    formatted_render_folder = StringTemplate(render_folder).format(render_data)
+    return os.path.normpath(os.path.join(render_data["work"], formatted_render_folder))
 
 
 def get_vray_settings(renderer_name: str, renderer: Any) -> Any:

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -78,7 +78,6 @@ class RenderProducts(object):
                     renderer_name
                 )
                 render_dict[aov_name] = aov_expected_files
-
         return render_dict
 
     def get_multiple_render_products(
@@ -220,7 +219,7 @@ class RenderProducts(object):
             if "GPU" in str(vr_renderer)
             else vr_renderer
         )
-        if not is_render_element and vray_settings.output_rawfilename:
+        if not is_render_element and not vray_settings.output_rawfilename:
             return ""
         output_attr = (
             "output_rawfilename"

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -219,8 +219,12 @@ class RenderProducts(object):
             if "GPU" in str(vr_renderer)
             else vr_renderer
         )
-        if not is_render_element and not vray_settings.output_rawfilename:
-            return ""
+        if (
+            not is_render_element
+            and image_format == "exr"
+            and not vray_settings.output_rawfilename
+        ):
+            return getattr(vray_settings, "output_splitfilename", "") or rt.rendOutputFilename
         output_attr = (
             "output_rawfilename"
             if not is_render_element and image_format == "exr"

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -61,8 +61,7 @@ class RenderProducts(object):
 
         # Always add beauty pass
         beauty_files = self.get_expected_beauty(start_frame, end_frame, extension)
-        if beauty_files:
-            render_dict["beauty"] = beauty_files
+        render_dict["beauty"] = beauty_files
 
         # Optionally add AOVs
         renderer = get_current_renderer()

--- a/client/ayon_max/api/lib_renderproducts.py
+++ b/client/ayon_max/api/lib_renderproducts.py
@@ -60,7 +60,9 @@ class RenderProducts(object):
         render_dict: Dict[str, list[str]] = {}
 
         # Always add beauty pass
-        render_dict["beauty"] = self.get_expected_beauty(start_frame, end_frame, extension)
+        beauty_files = self.get_expected_beauty(start_frame, end_frame, extension)
+        if beauty_files:
+            render_dict["beauty"] = beauty_files
 
         # Optionally add AOVs
         renderer = get_current_renderer()
@@ -218,6 +220,8 @@ class RenderProducts(object):
             if "GPU" in str(vr_renderer)
             else vr_renderer
         )
+        if not is_render_element and vray_settings.output_rawfilename:
+            return ""
         output_attr = (
             "output_rawfilename"
             if not is_render_element and image_format == "exr"
@@ -276,6 +280,8 @@ class RenderProducts(object):
             list[str]: List of expected file paths.
         """
         expected_aovs: list[str] = []
+        if not filepath:
+            return expected_aovs
         directory = os.path.dirname(filepath)
         filename = os.path.basename(filepath)
         name, ext = os.path.splitext(filename)

--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -86,7 +86,7 @@ class RenderSettings(object):
         # hard-coded, set the renderoutput path
         setting = self._project_settings
         container = self._data["instance_node"]
-        render_folder = get_default_render_folder(setting, self._data)
+        render_folder = get_default_render_folder(self._data, setting)
         filename, _ = os.path.splitext(file)
         output_dir = os.path.join(render_folder, filename)
         if not os.path.exists(output_dir):

--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -81,9 +81,9 @@ class RenderSettings(object):
         raise RuntimeError("Active Camera not found")
 
     def render_output(self):
-        # hard-coded, should be customized in the setting
+        # Set output paths for current workfile using project settings templates.
         file = rt.maxFileName
-        # hard-coded, set the renderoutput path
+        # Resolve project settings used for output path formatting.
         setting = self._project_settings
         container = self._data["instance_node"]
         render_folder = get_default_render_folder(self._data, setting)

--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -59,7 +59,7 @@ class RenderSettings(object):
         "underscore": "_"
     }
 
-    def __init__(self, project_settings=None):
+    def __init__(self, project_settings=None, data: dict=None):
         """
         Set up the naming convention for the render
         elements for the deadline submission
@@ -70,6 +70,7 @@ class RenderSettings(object):
             self._project_settings = get_project_settings(
                 get_current_project_name()
             )
+        self._data = data if data else {}
 
     def set_render_camera(self, selection):
         for sel in selection:
@@ -79,11 +80,12 @@ class RenderSettings(object):
                 return
         raise RuntimeError("Active Camera not found")
 
-    def render_output(self, container):
+    def render_output(self):
         # hard-coded, should be customized in the setting
         file = rt.maxFileName
         # hard-coded, set the renderoutput path
         setting = self._project_settings
+        container = self._data["instance_node"]
         render_folder = get_default_render_folder(setting)
         filename, _ = os.path.splitext(file)
         output_dir = os.path.join(render_folder, filename)
@@ -268,12 +270,11 @@ class RenderSettings(object):
             aov_name = f"{directory}_{camera}_{renderpass}..{ext}"
             render_elem.SetRenderElementFileName(i, aov_name)
 
-    def batch_render_layers_by_multi_camera(self, container, output_dir, cameras):
+    def batch_render_layers_by_multi_camera(self, output_dir, cameras):
         """Get the list of renderlayers for the multi-camera from batch render
         manager.
 
         Args:
-            container (str): container name
             output_dir (str): output render directory
             cameras (list): Cameras to create render layers for.
 
@@ -281,6 +282,7 @@ class RenderSettings(object):
             list: List of output filenames for the render layers
         """
         outputs = list()
+        container = self._data["instance_node"]
         output = os.path.join(output_dir, container)
         img_fmt = self._project_settings["max"]["RenderSettings"]["image_format"]   # noqa
         for cam in cameras:

--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -88,7 +88,8 @@ class RenderSettings(object):
         container = self._data["instance_node"]
         render_folder = get_default_render_folder(self._data, setting)
         filename, _ = os.path.splitext(file)
-        output_dir = os.path.join(render_folder, filename)
+        sync_name = self._data.get("sync_current_workfile_name", True)
+        output_dir = os.path.join(render_folder, filename.strip(".")) if sync_name else render_folder
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
         # hard-coded, should be customized in the setting

--- a/client/ayon_max/api/lib_rendersettings.py
+++ b/client/ayon_max/api/lib_rendersettings.py
@@ -86,7 +86,7 @@ class RenderSettings(object):
         # hard-coded, set the renderoutput path
         setting = self._project_settings
         container = self._data["instance_node"]
-        render_folder = get_default_render_folder(setting)
+        render_folder = get_default_render_folder(setting, self._data)
         filename, _ = os.path.splitext(file)
         output_dir = os.path.join(render_folder, filename)
         if not os.path.exists(output_dir):

--- a/client/ayon_max/api/validate_plugins.py
+++ b/client/ayon_max/api/validate_plugins.py
@@ -139,7 +139,6 @@ class ValidateRenderSettingsBase(object):
         """Get the invalid render output settings.
 
         Args:
-            instance (pyblish.api.Instance): The instance to validate.
             image_format (str): The image format to validate.
             workfile_pattern (str): The workfile pattern to validate.
             multicam (bool, optional): Whether multi-camera is enabled.

--- a/client/ayon_max/api/validate_plugins.py
+++ b/client/ayon_max/api/validate_plugins.py
@@ -134,16 +134,20 @@ class ValidateRenderSettingsBase(object):
         workfile_pattern: str,
         multicam: bool = False,
         cameras: Optional[list[str]] = None,
+        sync_current_workfile: bool = True,
     ) -> list[tuple[str, str]]:
         """Get the invalid render output settings.
 
         Args:
+            instance (pyblish.api.Instance): The instance to validate.
             image_format (str): The image format to validate.
             workfile_pattern (str): The workfile pattern to validate.
             multicam (bool, optional): Whether multi-camera is enabled.
                 Defaults to False.
             cameras (Optional[list[str]], optional): The list of camera names
                 to validate. Defaults to None.
+            sync_current_workfile (bool, optional): Whether to validate against the current
+                workfile name pattern. Defaults to True.
 
         Returns:
             list[tuple[str, str]]: A list of tuples containing the error type
@@ -151,7 +155,7 @@ class ValidateRenderSettingsBase(object):
         """
         invalid = []
         beauty_dir = os.path.dirname(rt.rendOutputFilename)
-        if workfile_pattern not in beauty_dir:
+        if sync_current_workfile and workfile_pattern not in beauty_dir:
             msg = (
                 f"Invalid render output filename {rt.rendOutputFilename}. "
                 f"Filename should contain the workfile name pattern: {workfile_pattern}."

--- a/client/ayon_max/plugins/create/create_render.py
+++ b/client/ayon_max/plugins/create/create_render.py
@@ -30,7 +30,7 @@ class CreateRender(MaxCreator):
                 "Please save the scene before creating render instance"
             )
         filename, _ = os.path.splitext(file)
-        instance_data["AssetName"] = filename
+        instance_data["original_workfile_pattern"] = filename.strip(".")
         instance_data["multiCamera"] = pre_create_data.get("multi_cam")
         num_of_renderlayer = rt.batchRenderMgr.numViews
         if num_of_renderlayer > 0:
@@ -47,9 +47,9 @@ class CreateRender(MaxCreator):
             instance_data,
             pre_create_data)
 
-        container_name = instance.data.get("instance_node")
+        render_settings = RenderSettings(data=instance.data)
         # set output paths for rendering(mandatory for deadline)
-        RenderSettings().render_output(container_name)
+        render_settings.render_output()
         # TODO: create multiple camera options
         if self.selected_nodes:
             selected_nodes_name = []
@@ -57,8 +57,8 @@ class CreateRender(MaxCreator):
                 name = sel.name
                 selected_nodes_name.append(name)
             output_dir = os.path.dirname(rt.rendOutputFilename)
-            RenderSettings().batch_render_layers_by_multi_camera(
-                container_name, output_dir, selected_nodes_name
+            render_settings.batch_render_layers_by_multi_camera(
+                output_dir, selected_nodes_name
             )
 
     def get_instance_attr_defs(self):

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -55,17 +55,20 @@ class CollectRender(pyblish.api.InstancePlugin):
     def process(self, instance):
         context = instance.context
 
+        filepath = context.data["currentFile"]
+
         if self.sync_current_workfile_name:
-            filepath = context.data["currentFile"]
             filename = os.path.basename(filepath)
             filename_pattern = os.path.splitext(filename)[0].strip(".")
             instance.data["original_workfile_pattern"] = filename_pattern
         else:
-            # backwards compatibility for render pre-create settings.
-            if instance.data.get("AssetName"):
-                filename_pattern = instance.data["AssetName"].strip(".")
-                instance.data["original_workfile_pattern"] = filename_pattern
-
+            # Backwards compatibility for render pre-create settings.
+            filename_pattern = (
+                instance.data.get("original_workfile_pattern")
+                or instance.data.get("AssetName", "").strip(".")
+            )
+            if filename_pattern:
+                instance.data.setdefault("original_workfile_pattern", filename_pattern)
         renderer = get_current_renderer()
         renderer_name = str(renderer).split(":")[0]
         renderproducts = RenderProducts(context.data["project_settings"])

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -67,8 +67,7 @@ class CollectRender(pyblish.api.InstancePlugin):
                 instance.data.get("original_workfile_pattern")
                 or instance.data.get("AssetName", "").strip(".")
             )
-            if filename_pattern:
-                instance.data.setdefault("original_workfile_pattern", filename_pattern)
+            instance.data["original_workfile_pattern"] = filename_pattern
         renderer = get_current_renderer()
         renderer_name = str(renderer).split(":")[0]
         renderproducts = RenderProducts(context.data["project_settings"])

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -50,12 +50,22 @@ class CollectRender(pyblish.api.InstancePlugin):
 
     # Settings
     sync_workfile_version = False
+    sync_current_workfile_name = True
 
     def process(self, instance):
         context = instance.context
-        filepath = context.data["currentFile"]
-        filename = os.path.basename(filepath)
-        filename_pattern = os.path.splitext(filename)[0].strip(".")
+
+        if self.sync_current_workfile_name:
+            filepath = context.data["currentFile"]
+            filename = os.path.basename(filepath)
+            filename_pattern = os.path.splitext(filename)[0].strip(".")
+            instance.data["original_workfile_pattern"] = filename_pattern
+        else:
+            # backwards compatibility for render pre-create settings.
+            if instance.data.get("AssetName"):
+                filename_pattern = instance.data["AssetName"].strip(".")
+                instance.data["original_workfile_pattern"] = filename_pattern
+
         renderer = get_current_renderer()
         renderer_name = str(renderer).split(":")[0]
         renderproducts = RenderProducts(context.data["project_settings"])
@@ -85,10 +95,9 @@ class CollectRender(pyblish.api.InstancePlugin):
                 context.data["project_settings"]
             )
             render_dir = os.path.dirname(render_output)
-
-            container_name = instance.data.get("instance_node")
-            outputs = RenderSettings().batch_render_layers_by_multi_camera(
-                container_name, render_dir, sel_cam
+            render_settings = RenderSettings(data=instance.data)
+            outputs = render_settings.batch_render_layers_by_multi_camera(
+                render_dir, sel_cam
             )
 
             instance.data["cameras"] = sel_cam
@@ -141,10 +150,8 @@ class CollectRender(pyblish.api.InstancePlugin):
         # also need to get the render dir for conversion
         data = {
             "folderPath": instance.data["folderPath"],
-            "workfile_name": filename,
             "productName": str(instance.name),
             "publish": True,
-            "original_workfile_pattern": filename_pattern,
             "maxversion": str(get_max_version()),
             "imageFormat": img_format,
             "productBaseType": product_base_type,
@@ -158,7 +165,8 @@ class CollectRender(pyblish.api.InstancePlugin):
             "frameEnd": instance.data["frameEndHandle"],
             "resolutionWidth": rt.renderWidth,
             "resolutionHeight": rt.renderHeight,
-            "farm": farm_render
+            "farm": farm_render,
+            "sync_current_workfile_name": self.sync_current_workfile_name,
         }
 
         # sync workfile version

--- a/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
+++ b/client/ayon_max/plugins/publish/save_scenes_for_cameras.py
@@ -40,15 +40,16 @@ class SaveScenesForCamera(pyblish.api.InstancePlugin):
             return
         new_folder = f"{current_folder}_{filename}"
         os.makedirs(new_folder, exist_ok=True)
+        render_settings = RenderSettings(data=instance.data)
         for camera in cameras:
-            new_output = RenderSettings().get_batch_render_output(camera)       # noqa
+            new_output = render_settings.get_batch_render_output(camera)       # noqa
             new_output = new_output.replace("\\", "/")
             camera_name = camera.replace(":", "_")
             new_filename = f"{filename}_{camera_name}{ext}"
             new_filepath = os.path.join(new_folder, new_filename)
             new_filepath = new_filepath.replace("\\", "/")
             camera_scene_files.append(new_filepath)
-            RenderSettings().batch_render_elements(camera)
+            render_settings.batch_render_elements(camera)
             rt.rendOutputFilename = new_output
             rt.saveMaxFile(current_filepath)
             script = ("""

--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -271,15 +271,16 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
         renderoutput = rt.rendOutputFilename
         project_settings = instance.context.data["project_settings"]
         if not renderoutput:
-            render_settings = RenderSettings(project_settings=project_settings, data=instance.data)
-            render_settings.render_output()
-            renderoutput = rt.rendOutputFilename
+            renderoutput = reset_rendersetting(instance, project_settings)
         output_dir = os.path.dirname(renderoutput)
         if instance.data.get("sync_current_workfile_name", True):
             output_dir = set_correct_workfile_name_for_render_output(
                 instance,
                 output_dir,
             )
+            if not output_dir:
+                renderoutput = reset_rendersetting(instance, project_settings)
+                output_dir = os.path.dirname(renderoutput)
         if renderer_name == "Redshift_Renderer":
             renderer.separateAovFiles = get_multipass_setting(
                 renderer_name,
@@ -319,6 +320,9 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
                     instance,
                     output_dir,
                 )
+                if not output_dir:
+                    renderoutput = reset_rendersetting(instance, project_settings)
+                    output_dir = os.path.dirname(renderoutput)
             output_filename = build_general_output_filename(output_dir, r_fname)
             render_elem.SetRenderElementFilename(index, output_filename)
             cls.log.info(
@@ -483,19 +487,17 @@ class ValidateArnoldRenderSetting(ValidateGenericRenderSetting):
         path = aov_manager.outputPath
         # check if the beauty output path is correct if using the
         # default native 3dsmax render
-        render_output = rt.rendOutputFilename
-        render_dir = os.path.dirname(render_output)
+        render_dir = os.path.dirname(path)
         if instance.data.get("sync_current_workfile_name", True):
             path = set_correct_workfile_name_for_render_output(
                 instance,
                 path,
             )
-            render_dir = set_correct_workfile_name_for_render_output(
-                instance,
-                render_dir,
-            )
+            if not path:
+                path = reset_rendersetting(instance, project_settings)
+                render_dir = os.path.dirname(path)
         aov_manager.outputPath = path
-        filename = os.path.basename(render_output)
+        filename = os.path.basename(path)
         rt.rendOutputFilename = build_general_output_filename(
             render_dir,
             filename,
@@ -784,6 +786,9 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
                     instance,
                     render_dir,
                 )
+                if not render_dir:
+                    render_output = reset_rendersetting(instance, project_settings)
+                    render_dir = os.path.dirname(render_output)
             filename = os.path.basename(render_output)
             rt.rendOutputFilename = build_general_output_filename(
                 render_dir,
@@ -809,18 +814,16 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
         """
         project_settings = instance.context.data["project_settings"]
         if not filename:
-            render_settings = RenderSettings(
-                project_settings=project_settings,
-                data=instance.data
-            )
-            render_settings.render_output()
-            filename = rt.rendOutputFilename
+            filename = reset_rendersetting(instance, project_settings)
         output_dir = os.path.dirname(filename)
         if instance.data.get("sync_current_workfile_name", True):
             output_dir = set_correct_workfile_name_for_render_output(
                 instance,
                 output_dir,
             )
+            if not output_dir:
+                filename = reset_rendersetting(instance, project_settings)
+                output_dir = os.path.dirname(filename)
         output_filename = os.path.basename(filename)
         return cls._build_vray_output_filename(
             output_dir,
@@ -845,6 +848,24 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
         Returns:
             str: The full path to the repaired V-Ray output file.
         """
-        name = os.path.splitext(filename)[0].lstrip(".")
+        name = os.path.splitext(filename)[0].strip(".")
         output_filename = f"{name}.{image_format}"
         return os.path.join(output_dir, output_filename)
+
+
+def reset_rendersetting(instance: pyblish.api.Instance, project_settings: dict) -> None:
+    """Reset the render settings for the given instance based on project settings.
+    This is built for customized render settings, and it will reset the render output path
+    to the default path based on the project settings.
+
+    Args:
+        instance (pyblish.api.Instance): The instance.
+        project_settings (dict): The project settings.
+
+    """
+    render_settings = RenderSettings(
+        project_settings=project_settings,
+        data=instance.data
+    )
+    render_settings.render_output()
+    return rt.rendOutputFilename

--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -218,7 +218,7 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
                     workfile_pattern,
                     multi_camera=multicam,
                     cameras=cameras,
-                    sync_current_workfile_name=instance.data.get("sync_current_workfile_name", True),
+                    sync_current_workfile_name=sync_current_workfile,
                 )
             )
             r_fname = os.path.basename(render_element_filename)
@@ -406,13 +406,17 @@ class ValidateArnoldRenderSetting(ValidateGenericRenderSetting):
         aov_manager = renderer.AOVManager
         output_path = aov_manager.outputPath
         image_format = instance.data["imageFormat"]
-        sync_current_workfile = instance.data.get("sync_current_workfile_name", True)
+        sync_current_workfile = instance.data.get(
+            "sync_current_workfile_name",
+            True,
+        )
         invalid.extend(
             cls.get_invalid_renderoutput(
-            image_format,
-            workfile_pattern,
-            sync_current_workfile=sync_current_workfile,
-        ))
+                image_format,
+                workfile_pattern,
+                sync_current_workfile=sync_current_workfile,
+            )
+        )
         if sync_current_workfile and workfile_pattern not in output_path:
             msg = (
                 f"Invalid Arnold AOV output path {output_path}. "

--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -190,12 +190,14 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
 
         multicam = instance.data.get("multiCamera", False)
         cameras = instance.data.get("cameras", [])
+        sync_current_workfile = instance.data.get("sync_current_workfile_name", True)
         invalid.extend(
             cls.get_invalid_renderoutput(
                 image_format,
                 workfile_pattern,
                 multicam=multicam,
                 cameras=cameras,
+                sync_current_workfile=sync_current_workfile,
             )
         )
 
@@ -404,12 +406,14 @@ class ValidateArnoldRenderSetting(ValidateGenericRenderSetting):
         aov_manager = renderer.AOVManager
         output_path = aov_manager.outputPath
         image_format = instance.data["imageFormat"]
+        sync_current_workfile = instance.data.get("sync_current_workfile_name", True)
         invalid.extend(
             cls.get_invalid_renderoutput(
             image_format,
-            workfile_pattern
+            workfile_pattern,
+            sync_current_workfile=sync_current_workfile,
         ))
-        if workfile_pattern not in output_path:
+        if sync_current_workfile and workfile_pattern not in output_path:
             msg = (
                 f"Invalid Arnold AOV output path {output_path}. "
                 f"Output path should contain the workfile name pattern: {workfile_pattern}."
@@ -700,9 +704,17 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
                     workfile_pattern,
                 )
             )
-        else:
+        elif not multipass_enabled:
+            sync_current_workfile = instance.data.get(
+                "sync_current_workfile_name",
+                True
+            )
             invalid.extend(
-                cls.get_invalid_renderoutput(image_format, workfile_pattern)
+                cls.get_invalid_renderoutput(
+                    image_format,
+                    workfile_pattern,
+                    sync_current_workfile=sync_current_workfile,
+                )
             )
 
         return invalid

--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -589,6 +589,7 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
         render_filepath: str,
         extension: str,
         workfile_pattern: str,
+        sync_current_workfile_name: bool = True,
     ) -> list[tuple[str, str]]:
         """Get invalid V-Ray filepaths for the given instance.
 
@@ -603,7 +604,7 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
         invalid = []
         render_dir = os.path.dirname(render_filepath)
         render_filename = os.path.basename(render_filepath)
-        if workfile_pattern not in render_dir:
+        if sync_current_workfile_name and workfile_pattern not in render_dir:
             msg = (
                 f"Invalid render output filename {render_filename} for V-Ray. "
                 f"Filename should contain the workfile name pattern: {workfile_pattern}."
@@ -633,6 +634,7 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
         filepath: str,
         extension: str,
         workfile_pattern: str,
+        sync_current_workfile_name: bool = True,
     ) -> list[tuple[str, str]]:
         """Get invalid V-Ray output settings for the given instance.
 
@@ -657,6 +659,7 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
             filepath,
             extension,
             workfile_pattern,
+            sync_current_workfile_name=sync_current_workfile_name,
         )
 
     @classmethod
@@ -685,6 +688,10 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
         vr_settings = get_vray_settings(renderer_name, renderer)
         image_format = instance.data["imageFormat"]
         multipass_enabled = get_multipass_setting(renderer_name, project_settings)
+        sync_current_workfile = instance.data.get(
+            "sync_current_workfile_name",
+            True
+        )
         if multipass_enabled != vr_settings.output_splitgbuffer:
             invalid.append((
                 "Invalid V-Ray multipass setting",
@@ -697,6 +704,7 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
                     vr_settings.output_rawfilename,
                     image_format,
                     workfile_pattern,
+                    sync_current_workfile_name=sync_current_workfile,
                 )
             )
 
@@ -706,13 +714,10 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
                     vr_settings.output_splitfilename,
                     image_format,
                     workfile_pattern,
+                    sync_current_workfile_name=sync_current_workfile,
                 )
             )
         elif not multipass_enabled:
-            sync_current_workfile = instance.data.get(
-                "sync_current_workfile_name",
-                True
-            )
             invalid.extend(
                 cls.get_invalid_renderoutput(
                     image_format,

--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -717,7 +717,7 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
                     sync_current_workfile_name=sync_current_workfile,
                 )
             )
-        elif not multipass_enabled:
+        else:
             invalid.extend(
                 cls.get_invalid_renderoutput(
                     image_format,

--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -110,6 +110,7 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
         workfile_pattern: str,
         multi_camera: bool = False,
         cameras: Optional[list[str]] = None,
+        sync_current_workfile_name: bool = True,
     ) -> list[tuple[str, str]]:
         """Get the invalid render element directory settings.
 
@@ -120,13 +121,15 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
             Defaults to False.
             cameras (Optional[list[str]], optional): The list of camera
                 names to validate. Defaults to None.
+            sync_current_workfile_name (bool, optional): Whether to sync workfile name.
+                Defaults to True.
 
         Returns:
             list[tuple[str, str]]: A list of tuples containing the error
                 type and the invalid directory.
         """
         invalid = []
-        if workfile_pattern not in directory:
+        if sync_current_workfile_name and workfile_pattern not in directory:
             msg = (
                 f"Invalid render element output directory {directory}. "
                 f"Directory should contain the workfile name pattern: {workfile_pattern}."
@@ -213,6 +216,7 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
                     workfile_pattern,
                     multi_camera=multicam,
                     cameras=cameras,
+                    sync_current_workfile_name=instance.data.get("sync_current_workfile_name", True),
                 )
             )
             r_fname = os.path.basename(render_element_filename)
@@ -237,9 +241,12 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
             return
 
         if instance.data.get("multiCamera"):
-            instance_node = instance.data.get("instance_node")
             project_settings = instance.context.data["project_settings"]
-            RenderSettings(project_settings).render_output(instance_node)
+            render_settings = RenderSettings(
+                project_settings=project_settings,
+                data=instance.data
+            )
+            render_settings.render_output()
             return
 
         cls.repair_generic_render_settings(instance, renderer_name, renderer)
@@ -262,15 +269,15 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
         renderoutput = rt.rendOutputFilename
         project_settings = instance.context.data["project_settings"]
         if not renderoutput:
-            RenderSettings(project_settings).render_output(
-                instance.data.get("instance_node")
-            )
+            render_settings = RenderSettings(project_settings=project_settings, data=instance.data)
+            render_settings.render_output()
             renderoutput = rt.rendOutputFilename
-
-        output_dir = set_correct_workfile_name_for_render_output(
-            instance,
-            os.path.dirname(renderoutput),
-        )
+        output_dir = os.path.dirname(renderoutput)
+        if instance.data.get("sync_current_workfile_name", True):
+            output_dir = set_correct_workfile_name_for_render_output(
+                instance,
+                output_dir,
+            )
         if renderer_name == "Redshift_Renderer":
             renderer.separateAovFiles = get_multipass_setting(
                 renderer_name,
@@ -304,10 +311,12 @@ class ValidateGenericRenderSetting(pyblish.api.InstancePlugin,
 
             render_element_filename = render_elem.GetRenderElementFilename(index)
             r_fname = os.path.basename(render_element_filename)
-            output_dir = set_correct_workfile_name_for_render_output(
-                instance,
-                os.path.dirname(render_element_filename),
-            )
+            output_dir = os.path.dirname(render_element_filename)
+            if instance.data.get("sync_current_workfile_name", True):
+                output_dir = set_correct_workfile_name_for_render_output(
+                    instance,
+                    output_dir,
+                )
             output_filename = build_general_output_filename(output_dir, r_fname)
             render_elem.SetRenderElementFilename(index, output_filename)
             cls.log.info(
@@ -463,18 +472,21 @@ class ValidateArnoldRenderSetting(ValidateGenericRenderSetting):
         image_format = instance.data["imageFormat"]
         project_settings = instance.context.data["project_settings"]
         aov_manager = renderer.AOVManager
-        path = set_correct_workfile_name_for_render_output(
-            instance,
-            aov_manager.outputPath,
-        )
-        aov_manager.outputPath = path
+        path = aov_manager.outputPath
         # check if the beauty output path is correct if using the
         # default native 3dsmax render
         render_output = rt.rendOutputFilename
-        render_dir = set_correct_workfile_name_for_render_output(
-            instance,
-            os.path.dirname(render_output),
-        )
+        render_dir = os.path.dirname(render_output)
+        if instance.data.get("sync_current_workfile_name", True):
+            path = set_correct_workfile_name_for_render_output(
+                instance,
+                path,
+            )
+            render_dir = set_correct_workfile_name_for_render_output(
+                instance,
+                render_dir,
+            )
+        aov_manager.outputPath = path
         filename = os.path.basename(render_output)
         rt.rendOutputFilename = build_general_output_filename(
             render_dir,
@@ -745,10 +757,12 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
             )
         else:
             render_output = rt.rendOutputFilename
-            render_dir = set_correct_workfile_name_for_render_output(
-                instance,
-                os.path.dirname(render_output),
-            )
+            render_dir = os.path.dirname(render_output)
+            if instance.data.get("sync_current_workfile_name", True):
+                render_dir = set_correct_workfile_name_for_render_output(
+                    instance,
+                    render_dir,
+                )
             filename = os.path.basename(render_output)
             rt.rendOutputFilename = build_general_output_filename(
                 render_dir,
@@ -772,16 +786,20 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
         Returns:
             str: The repaired V-Ray output filename.
         """
-        instance_node = instance.data.get("instance_node")
         project_settings = instance.context.data["project_settings"]
         if not filename:
-            RenderSettings(project_settings).render_output(instance_node)
+            render_settings = RenderSettings(
+                project_settings=project_settings,
+                data=instance.data
+            )
+            render_settings.render_output()
             filename = rt.rendOutputFilename
-
-        output_dir = set_correct_workfile_name_for_render_output(
-            instance,
-            os.path.dirname(filename),
-        )
+        output_dir = os.path.dirname(filename)
+        if instance.data.get("sync_current_workfile_name", True):
+            output_dir = set_correct_workfile_name_for_render_output(
+                instance,
+                output_dir,
+            )
         output_filename = os.path.basename(filename)
         return cls._build_vray_output_filename(
             output_dir,

--- a/client/ayon_max/plugins/publish/validate_rendersettings.py
+++ b/client/ayon_max/plugins/publish/validate_rendersettings.py
@@ -853,14 +853,18 @@ class ValidateVrayRenderSetting(ValidateGenericRenderSetting):
         return os.path.join(output_dir, output_filename)
 
 
-def reset_rendersetting(instance: pyblish.api.Instance, project_settings: dict) -> None:
+def reset_rendersetting(instance: pyblish.api.Instance, project_settings: dict) -> str:
     """Reset the render settings for the given instance based on project settings.
+
     This is built for customized render settings, and it will reset the render output path
     to the default path based on the project settings.
 
     Args:
         instance (pyblish.api.Instance): The instance.
         project_settings (dict): The project settings.
+
+    Returns:
+        str: The resulting render output filename (rt.rendOutputFilename).
 
     """
     render_settings = RenderSettings(

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -11,7 +11,7 @@ class CollectRenderModel(BaseSettingsModel):
     )
     sync_current_workfile_name: bool = SettingsField(
         title="Sync current workfile name to instance data"
-    )s
+    )
 
 
 class ValidateAttributesModel(BaseSettingsModel):

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -160,7 +160,8 @@ class PublishersModel(BaseSettingsModel):
 
 DEFAULT_PUBLISH_SETTINGS = {
     "CollectRender": {
-        "sync_workfile_version": False
+        "sync_workfile_version": False,
+        "sync_current_workfile_name": True
     },
     "ValidateInstanceInContext": {
         "enabled": True,

--- a/server/settings/publishers.py
+++ b/server/settings/publishers.py
@@ -9,6 +9,9 @@ class CollectRenderModel(BaseSettingsModel):
     sync_workfile_version: bool = SettingsField(
         title="Sync render version with workfile"
     )
+    sync_current_workfile_name: bool = SettingsField(
+        title="Sync current workfile name to instance data"
+    )s
 
 
 class ValidateAttributesModel(BaseSettingsModel):

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -57,7 +57,7 @@ class RenderSettingsModel(BaseSettingsModel):
 
 
 DEFAULT_RENDER_SETTINGS = {
-    "default_render_image_folder": "{work}/renders/3dsmax/{product[name]}",
+    "default_render_image_folder": "{work}/renders/3dsmax/{productName}",
     "aov_separator": "underscore",
     "image_format": "exr",
     "vray_render_settings": {

--- a/server/settings/render_settings.py
+++ b/server/settings/render_settings.py
@@ -57,7 +57,7 @@ class RenderSettingsModel(BaseSettingsModel):
 
 
 DEFAULT_RENDER_SETTINGS = {
-    "default_render_image_folder": "renders/3dsmax",
+    "default_render_image_folder": "{work}/renders/3dsmax/{product[name]}",
     "aov_separator": "underscore",
     "image_format": "exr",
     "vray_render_settings": {


### PR DESCRIPTION
## Changelog Description
This PR is to enhance the user customization for 3dsmax render folder. Users can use template-style to customize default 3dsmax render folder. There is also an option in Collect Render in addon-settings (`ayon+settings://max/publish/CollectRender/sync_current_workfile_name`) to let users to choose whether they want to synchronize the current workfile name, of which is included in the creation of the 3dsmax render folder by default. If the toggle is turned off, the validator would skip the check on whether the 3dsmax render folder is included with the current workfile name.

## Additional review information
Fixes https://github.com/ynput/ayon-3dsmax/issues/143
You can use the following template below:
`root[work]`: project path
`folderPath` : folderPath
`task`: Task Name
`version` : version number
`{work}`: default work directory
`{subset}` : product Name
`{product[name]}` : product Name
`{family}`: product base type
`{product[type]}`: product type
`{product[basetype]}`: product base type
`{productName}` : product Name
`{productBaseType}` : product base type

## Testing notes:
We should test with three scenarios.
First
1. Tested with default settings for `ayon+settings://max/RenderSettings/default_render_image_folder` and `ayon+settings://max/publish/CollectRender/sync_current_workfile_name`
2. Publish successfully 
3. And then Publish again
4. Validation blocks
5. Publish successfully

Second
1. Tested with default settings for `ayon+settings://max/RenderSettings/default_render_image_folder` 
2. Turns off the toggle for `ayon+settings://max/publish/CollectRender/sync_current_workfile_name`
3. Publish successfully
4. And then Publish successfully

Third
1. Tested with default settings for `ayon+settings://max/RenderSettings/default_render_image_folder` 
2. Turns off the toggle for `ayon+settings://max/publish/CollectRender/sync_current_workfile_name`
3. Publish successfully
4. Go to Render Settings and edit the output path without any workfile name inside
5. Publish should still be succeeded without any error.

All three scenarios should be published successfully for both local and farm rendering.