### PR TITLE
Collect Render: Correct colorspace updated in render instance

### DIFF
--- a/client/ayon_max/api/colorspace.py
+++ b/client/ayon_max/api/colorspace.py
@@ -9,48 +9,61 @@ except ImportError:
 
 
 @attr.s
-class LayerMetadata(object):
-    """Data class for Render Layer metadata."""
-    frameStart = attr.ib()
-    frameEnd = attr.ib()
-
-
-@attr.s
 class RenderProduct(object):
     """Getting Colorspace as
     Specific Render Product Parameter for submitting
     publish job.
     """
-    colorspace = attr.ib()                      # colorspace
-    view = attr.ib()
-    productName = attr.ib(default=None)
+    productName = attr.ib(default="")
+    colorspace = attr.ib(default="sRGB")
+    view = attr.ib(default="ACES 1.0")
+    display = attr.ib(default="sRGB")
+
+
+@attr.s
+class LayerMetadata(object):
+    """Data class for Render Layer metadata."""
+    frameStart = attr.ib()
+    frameEnd = attr.ib()
+    products: list[RenderProduct] = attr.ib(factory=list)
 
 
 class ARenderProduct(object):
 
-    def __init__(self):
+    def __init__(self, frame_start, frame_end):
         """Constructor."""
         # Initialize
-        self.layer_data = self._get_layer_data()
-        self.layer_data.products = self.get_colorspace_data()
+        self.layer_data = self._get_layer_data(frame_start, frame_end)
 
-    def _get_layer_data(self):
+    def _get_layer_data(
+        self,
+        frame_start: int,
+        frame_end: int
+    ) -> LayerMetadata:
         return LayerMetadata(
-            frameStart=int(rt.rendStart),
-            frameEnd=int(rt.rendEnd),
+            frameStart=int(frame_start),
+            frameEnd=int(frame_end),
         )
 
-    def get_colorspace_data(self):
-        """To be implemented by renderer class.
-        This should return a list of RenderProducts.
-        Returns:
-            list: List of RenderProduct
+
+    def add_colorspace_data(
+        self,
+        product_name: str,
+        colorspace: str,
+        view: str,
+        display: str
+    ) -> None:
+        """Add colorspace data to the render product.
+
+        Args:
+            product_name (str): The name of the render product.
+            colorspace (str): The colorspace of the render product.
+            view (str): The view of the render product.
+            display (str): The display of the render product.
         """
-        colorspace_data = [
-            RenderProduct(
-                colorspace="sRGB",
-                view="ACES 1.0",
-                productName=""
-            )
-        ]
-        return colorspace_data
+        self.layer_data.products.append(RenderProduct(
+            productName=product_name,
+            colorspace=colorspace,
+            view=view,
+            display=display
+        ))

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -180,18 +180,20 @@ class CollectRender(pyblish.api.InstancePlugin):
 
         self.log.info("data: {0}".format(data))
 
-    def get_colorspace_data(self) -> dict[str, str] | None:
+    def get_colorspace_data(self) -> Dict[str, str]:
         """Get colorspace data from the ColorPipelineMgr.
 
         Returns:
-            dict[str, str] | None: A dictionary containing
-                colorspace data or None if not available.
+            Dict[str, str]: A dictionary containing colorspace data. Empty dict
+                is returned when colorspace data is not available.
         """
+        if int(get_max_version()) < 2024:
+            return {}
+
         colorspace_mgr = rt.ColorPipelineMgr
         ocio_path: str = colorspace_mgr.OCIOConfigPath
         if not ocio_path:
-            return None
-
+            return {}
         display: str = pymxs.pyref("")
         view: str = pymxs.pyref("")
         colorspace_mgr.GetDefaultDisplayViewTransform(

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -106,7 +106,7 @@ class CollectRender(pyblish.api.InstancePlugin):
         # OCIO config not support in
         # most of the 3dsmax renderers
         # so this is currently hard coded
-        colorspace_data = self.get_colorspace_data()
+        colorspace_data = self.get_colorspace_data() or {}
         self.log.debug(f"Collected colorspace data: {colorspace_data}")
         if colorspace_data:
             instance.data.update(colorspace_data)
@@ -115,12 +115,13 @@ class CollectRender(pyblish.api.InstancePlugin):
             instance.data["frameStartHandle"],
             instance.data["frameEndHandle"]
         )
-        instance.data["renderProducts"] = colorspace_product.add_colorspace_data(
+        colorspace_product.add_colorspace_data(
             product_name=str(instance.name),
             colorspace=colorspace_data.get("colorspace", "sRGB"),
             view=colorspace_data.get("sceneView", "ACES 1.0"),
             display=colorspace_data.get("sceneDisplay", "sRGB")
         )
+        instance.data["renderProducts"] = colorspace_product
 
         instance.data["publishJobState"] = "Suspended"
         instance.data["attachTo"] = []

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -6,6 +6,7 @@ import pyblish.api
 import ayon_api
 from typing import Dict, Any
 
+import pymxs
 from pymxs import runtime as rt
 from ayon_core.pipeline.publish import KnownPublishError
 from ayon_max.api import colorspace
@@ -105,22 +106,22 @@ class CollectRender(pyblish.api.InstancePlugin):
         # OCIO config not support in
         # most of the 3dsmax renderers
         # so this is currently hard coded
-        # TODO: add options for redshift/vray ocio config
-        instance.data["colorspaceConfig"] = ""
-        instance.data["colorspaceDisplay"] = "sRGB"
-        instance.data["colorspaceView"] = "ACES 1.0 SDR-video"
+        colorspace_data = self.get_colorspace_data()
+        self.log.debug(f"Collected colorspace data: {colorspace_data}")
+        if colorspace_data:
+            instance.data.update(colorspace_data)
 
-        if int(get_max_version()) >= 2024:
-            colorspace_mgr = rt.ColorPipelineMgr      # noqa
-            display = next(
-                (display for display in colorspace_mgr.GetDisplayList()))
-            view_transform = next(
-                (view for view in colorspace_mgr.GetViewList(display)))
-            instance.data["colorspaceConfig"] = colorspace_mgr.OCIOConfigPath
-            instance.data["colorspaceDisplay"] = display
-            instance.data["colorspaceView"] = view_transform
+        colorspace_product = colorspace.ARenderProduct(
+            instance.data["frameStartHandle"],
+            instance.data["frameEndHandle"]
+        )
+        instance.data["renderProducts"] = colorspace_product.add_colorspace_data(
+            product_name=str(instance.name),
+            colorspace=colorspace_data.get("colorspace", "sRGB"),
+            view=colorspace_data.get("sceneView", "ACES 1.0"),
+            display=colorspace_data.get("sceneDisplay", "sRGB")
+        )
 
-        instance.data["renderProducts"] = colorspace.ARenderProduct()
         instance.data["publishJobState"] = "Suspended"
         instance.data["attachTo"] = []
 
@@ -177,6 +178,34 @@ class CollectRender(pyblish.api.InstancePlugin):
                     "renderers.current.separateAovFiles")})
 
         self.log.info("data: {0}".format(data))
+
+    def get_colorspace_data(self) -> dict[str, str] | None:
+        """Get colorspace data from the ColorPipelineMgr.
+
+        Returns:
+            dict[str, str] | None: A dictionary containing
+                colorspace data or None if not available.
+        """
+        colorspace_mgr = rt.ColorPipelineMgr
+        ocio_path: str = colorspace_mgr.OCIOConfigPath
+        if not ocio_path:
+            return None
+
+        display: str = pymxs.pyref("")
+        view: str = pymxs.pyref("")
+        colorspace_mgr.GetDefaultDisplayViewTransform(
+            rt.Name("Global"),
+            False,
+            display,
+            view
+        )
+
+        return {
+            "colorspaceConfig": ocio_path,
+            "sceneDisplay": display.value,
+            "sceneView": view.value,
+            "colorspace": colorspace_mgr.RenderingColorSpace
+        }
 
     def get_render_output(
             self,

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -194,19 +194,19 @@ class CollectRender(pyblish.api.InstancePlugin):
         ocio_path: str = colorspace_mgr.OCIOConfigPath
         if not ocio_path:
             return {}
-        display: str = pymxs.byref("")
-        view: str = pymxs.byref("")
-        colorspace_mgr.GetDefaultDisplayViewTransform(
+        display_ref: str = pymxs.byref("")
+        view_ref: str = pymxs.byref("")
+        _, display, view =colorspace_mgr.GetDefaultDisplayViewTransform(
             rt.Name("Global"),
             False,
-            display,
-            view
+            display_ref,
+            view_ref
         )
 
         return {
             "colorspaceConfig": ocio_path,
-            "sceneDisplay": display.value,
-            "sceneView": view.value,
+            "sceneDisplay": display,
+            "sceneView": view,
             "colorspace": colorspace_mgr.RenderingColorSpace
         }
 

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -194,8 +194,8 @@ class CollectRender(pyblish.api.InstancePlugin):
         ocio_path: str = colorspace_mgr.OCIOConfigPath
         if not ocio_path:
             return {}
-        display: str = pymxs.pyref("")
-        view: str = pymxs.pyref("")
+        display: str = pymxs.byref("")
+        view: str = pymxs.byref("")
         colorspace_mgr.GetDefaultDisplayViewTransform(
             rt.Name("Global"),
             False,

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -194,8 +194,8 @@ class CollectRender(pyblish.api.InstancePlugin):
         ocio_path: str = colorspace_mgr.OCIOConfigPath
         if not ocio_path:
             return {}
-        display_ref: str = pymxs.byref("")
-        view_ref: str = pymxs.byref("")
+        display_ref = pymxs.byref("")
+        view_ref = pymxs.byref("")
         _, display, view =colorspace_mgr.GetDefaultDisplayViewTransform(
             rt.Name("Global"),
             False,

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -191,8 +191,8 @@ class CollectRender(pyblish.api.InstancePlugin):
         if not ocio_path:
             return None
 
-        display: str = pymxs.pyref("")
-        view: str = pymxs.pyref("")
+        display: str = pymxs.byref("")
+        view: str = pymxs.byref("")
         colorspace_mgr.GetDefaultDisplayViewTransform(
             rt.Name("Global"),
             False,


### PR DESCRIPTION
## Changelog Description
This PR is to make sure correct colorspace data updated in render instance.

## Additional review information
Resolve https://github.com/ynput/ayon-3dsmax/issues/150
Make sure you enable color management in both 3dsmax and Core addon.
Better test on Farm as you can notice the data in metadata.json
## Testing notes:
1. Create Render
2. Publish
3. Check if the colorspace data aligning with your 3dsmax colorspace setting.
