### PR TITLE
Render: Transfer the colorspace data in terms of the local rendering

### DIFF
--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -138,11 +138,11 @@ class CollectRender(pyblish.api.InstancePlugin):
                 colorspace_product.add_colorspace_data(
                     product_name=aov_name,
                     colorspace=colorspace_data["colorspace"],
-                    view=colorspace_data,
-                    display=colorspace_data.get("sceneDisplay", "sRGB")
+                    view=colorspace_data["sceneView"],
+                    display=colorspace_data["sceneDisplay"]
                 )
 
-            instance.data["renderProducts"] = colorspace_product
+        instance.data["renderProducts"] = colorspace_product
 
         data = {
             "folderPath": instance.data["folderPath"],

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -142,7 +142,6 @@ class CollectRender(pyblish.api.InstancePlugin):
             )
             instance.data["renderProducts"] = colorspace_product
 
-        # also need to get the render dir for conversion
         data = {
             "folderPath": instance.data["folderPath"],
             "workfile_name": filename,

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -129,17 +129,19 @@ class CollectRender(pyblish.api.InstancePlugin):
         self._precollect_required_data(instance)
 
         # set the colorspace data for each AOV in the instance data
-        for aov_name in files_by_aov.keys():
+        if colorspace_data:
             colorspace_product = colorspace.ARenderProduct(
                 instance.data["frameStartHandle"],
                 instance.data["frameEndHandle"]
             )
-            colorspace_product.add_colorspace_data(
-                product_name=aov_name,
-                colorspace=colorspace_data.get("colorspace", "sRGB"),
-                view=colorspace_data.get("sceneView", "ACES 1.0"),
-                display=colorspace_data.get("sceneDisplay", "sRGB")
-            )
+            for aov_name in files_by_aov.keys():
+                colorspace_product.add_colorspace_data(
+                    product_name=aov_name,
+                    colorspace=colorspace_data["colorspace"],
+                    view=colorspace_data,
+                    display=colorspace_data.get("sceneDisplay", "sRGB")
+                )
+
             instance.data["renderProducts"] = colorspace_product
 
         data = {

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -111,18 +111,6 @@ class CollectRender(pyblish.api.InstancePlugin):
         if colorspace_data:
             instance.data.update(colorspace_data)
 
-        colorspace_product = colorspace.ARenderProduct(
-            instance.data["frameStartHandle"],
-            instance.data["frameEndHandle"]
-        )
-        colorspace_product.add_colorspace_data(
-            product_name=str(instance.name),
-            colorspace=colorspace_data.get("colorspace", "sRGB"),
-            view=colorspace_data.get("sceneView", "ACES 1.0"),
-            display=colorspace_data.get("sceneDisplay", "sRGB")
-        )
-        instance.data["renderProducts"] = colorspace_product
-
         instance.data["publishJobState"] = "Suspended"
         instance.data["attachTo"] = []
 
@@ -139,6 +127,20 @@ class CollectRender(pyblish.api.InstancePlugin):
             creator_attribute.get("render_target", "farm") == "farm"
         )
         self._precollect_required_data(instance)
+
+        # set the colorspace data for each AOV in the instance data
+        for aov_name in files_by_aov.keys():
+            colorspace_product = colorspace.ARenderProduct(
+                instance.data["frameStartHandle"],
+                instance.data["frameEndHandle"]
+            )
+            colorspace_product.add_colorspace_data(
+                product_name=aov_name,
+                colorspace=colorspace_data.get("colorspace", "sRGB"),
+                view=colorspace_data.get("sceneView", "ACES 1.0"),
+                display=colorspace_data.get("sceneDisplay", "sRGB")
+            )
+            instance.data["renderProducts"] = colorspace_product
 
         # also need to get the render dir for conversion
         data = {

--- a/client/ayon_max/plugins/publish/collect_render_local.py
+++ b/client/ayon_max/plugins/publish/collect_render_local.py
@@ -5,6 +5,7 @@ from ayon_core.pipeline.farm.pyblish_functions import (
     create_instances_for_aov
 )
 
+
 class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
     """Collect instances for local render.
     """
@@ -18,6 +19,10 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
         "instance_node",
         "members",
         "cameras",
+        "colorspaceConfig",
+        "colorspace",
+        "sceneDisplay",
+        "sceneView",
     }
 
     def process(self, instance):
@@ -67,7 +72,6 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
             # absolute again.
             for repre in aov_instance_data["representations"]:
                 repre["stagingDir"] = anatomy.fill_root(repre["stagingDir"])
-
             aov_instance = context.create_instance(
                 aov_instance_data["productName"]
             )
@@ -77,6 +81,7 @@ class CollectLocalRenderInstances(pyblish.api.InstancePlugin):
             # Pass on 'review' family
             if "review" in aov_instance_data["families"]:
                 aov_instance.data["families"].append("review")
+
         # Skip integrating original render instance.
         # We are not removing it because it's used to trigger the render.
         instance.data["integrate"] = False


### PR DESCRIPTION
## Changelog Description
This PR is the continuity of https://github.com/ynput/ayon-3dsmax/pull/151 to make sure the colorspace data has been transferred per aov instance in terms of the local rendering.


## Additional review information
Resolve https://github.com/ynput/ayon-3dsmax/issues/150
Make sure you enable color management in both 3dsmax and Core addon.

## Testing notes:
1. Tested with local and farm rendering
2. When extracting the colorspace data in local rendering, you should see
<img width="1299" height="824" alt="image" src="https://github.com/user-attachments/assets/9ec36f5c-1caf-449e-aaf0-a9bd4d014d71" />
3. Speaking of the farm rendering, you should find the relevant data in the metadata.json as you see in  https://github.com/ynput/ayon-3dsmax/issues/150 and you can find the ExtractColorspaceData to extract colorspace data as expected in deadline log for the headless mode of the AYON publish.
<img width="1934" height="906" alt="image" src="https://github.com/user-attachments/assets/8f5cdc3f-3e0b-449c-83f2-fe648c8b278e" />
