### PR TITLE
Render: Colorspace handling require explicit values without fallback

### DIFF
--- a/client/ayon_max/api/colorspace.py
+++ b/client/ayon_max/api/colorspace.py
@@ -16,7 +16,7 @@ class RenderProduct(object):
     """
     productName = attr.ib(default="")
     colorspace = attr.ib(default="sRGB")
-    view = attr.ib(default="ACES 1.0")
+    view = attr.ib(default="ACES")
     display = attr.ib(default="sRGB")
 
 

--- a/client/ayon_max/api/colorspace.py
+++ b/client/ayon_max/api/colorspace.py
@@ -15,9 +15,9 @@ class RenderProduct(object):
     publish job.
     """
     productName = attr.ib(default="")
-    colorspace = attr.ib(default="sRGB")
-    view = attr.ib(default="ACES")
-    display = attr.ib(default="sRGB")
+    colorspace = attr.ib(default=None)
+    view = attr.ib(default=None)
+    display = attr.ib(default=None)
 
 
 @attr.s

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -141,8 +141,8 @@ class CollectRender(pyblish.api.InstancePlugin):
 
         # set the colorspace data for each AOV in the instance data
         colorspace_product = colorspace.ARenderProduct(
-            instance.data["frameStartHandle"],
-            instance.data["frameEndHandle"]
+            instance.data.get("frameStartHandle"),
+            instance.data.get("frameEndHandle")
         )
         if colorspace_data:
             for aov_name in files_by_aov.keys():

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -140,11 +140,11 @@ class CollectRender(pyblish.api.InstancePlugin):
         self._precollect_required_data(instance)
 
         # set the colorspace data for each AOV in the instance data
+        colorspace_product = colorspace.ARenderProduct(
+            instance.data["frameStartHandle"],
+            instance.data["frameEndHandle"]
+        )
         if colorspace_data:
-            colorspace_product = colorspace.ARenderProduct(
-                instance.data["frameStartHandle"],
-                instance.data["frameEndHandle"]
-            )
             for aov_name in files_by_aov.keys():
                 colorspace_product.add_colorspace_data(
                     product_name=aov_name,

--- a/client/ayon_max/plugins/publish/collect_render.py
+++ b/client/ayon_max/plugins/publish/collect_render.py
@@ -141,8 +141,8 @@ class CollectRender(pyblish.api.InstancePlugin):
 
         # set the colorspace data for each AOV in the instance data
         colorspace_product = colorspace.ARenderProduct(
-            instance.data.get("frameStartHandle"),
-            instance.data.get("frameEndHandle")
+            instance.data["frameStartHandle"],
+            instance.data["frameEndHandle"]
         )
         if colorspace_data:
             for aov_name in files_by_aov.keys():


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the colorspace handling require explicit values without fallback. If there is no colorspace data, the colorspace from the RenderProduct set to None.

## Additional review information
n/a

## Testing notes:
1. Create Render
2. Publish
