### PR TITLE
Templated Builder: options to trigger when application launch or always on new scene

### DIFF
--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -274,7 +274,13 @@ def get_containers() -> List:
     ]
 
 
-def on_init():
+def on_init() -> None:
+    """Callback for initialization event."""
+    if lib.is_headless():
+        return
+    from .workfile_template_builder import trigger_on_app_launch
+    trigger_on_app_launch()
+
     if not os.path.exists(rt.ColorPipelineMgr.OCIOConfigPath):
         lib.reset_colorspace()
     last_workfile = os.getenv("AYON_LAST_WORKFILE")
@@ -283,7 +289,12 @@ def on_init():
             lib.set_context_settings()
 
 
-def on_new():
+def on_new() -> None:
+    """Callback for new scene event."""
+    if lib.is_headless():
+        return
+    from .workfile_template_builder import trigger_on_new_file
+    trigger_on_new_file()
     lib.set_context_settings()
 
 

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -114,6 +114,8 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return filepath
 
     def get_current_workfile(self):
+        if not rt.maxFileName or not rt.maxFilePath:
+            return ""
         return os.path.normpath(
             os.path.join(rt.maxFilePath, rt.maxFileName)
         )

--- a/client/ayon_max/api/workfile_template_builder.py
+++ b/client/ayon_max/api/workfile_template_builder.py
@@ -222,7 +222,7 @@ def trigger_on_app_launch() -> None:
     """
     builder = MaxTemplateBuilder(registered_host())
     preset = builder.get_template_preset()
-    if preset.execute_on_new_file and not preset.execute_on_app_launch:
+    if preset.execute_on_new_file and preset.execute_on_app_launch:
         builder.trigger_on_new_file()
     else:
         builder.trigger_on_app_launch()
@@ -246,6 +246,8 @@ def build_workfile_template() -> None:
     """Build the workfile template for 3ds Max."""
     builder = MaxTemplateBuilder(registered_host())
     preset = builder.get_template_preset()
+    if not preset.has_valid_path():
+        return
     builder.build_template(preset=preset)
 
 

--- a/client/ayon_max/api/workfile_template_builder.py
+++ b/client/ayon_max/api/workfile_template_builder.py
@@ -216,16 +216,37 @@ class MaxPlaceholderPlugin(PlaceholderPlugin):
         imprint(node, data)
 
 
-def create_first_workfile_from_template(*args) -> None:
+def trigger_on_app_launch() -> None:
+    """Build the workfile template during application
+    launch if the setting is enabled.
+    """
+    builder = MaxTemplateBuilder(registered_host())
+    preset = builder.get_template_preset()
+    if preset.execute_on_new_file and not preset.execute_on_app_launch:
+        builder.trigger_on_new_file()
+    else:
+        builder.trigger_on_app_launch()
+
+
+def trigger_on_new_file() -> None:
+    """Build the workfile template during new file creation
+    if the setting is enabled.
+    """
+    builder = MaxTemplateBuilder(registered_host())
+    builder.trigger_on_new_file()
+
+
+def create_first_workfile_from_template() -> None:
     """Create the first workfile from template for 3ds Max."""
     builder = MaxTemplateBuilder(registered_host())
-    builder.build_template(workfile_creation_enabled=True)
+    builder.create_first_workfile_version()
 
 
-def build_workfile_template(*args) -> None:
+def build_workfile_template() -> None:
     """Build the workfile template for 3ds Max."""
     builder = MaxTemplateBuilder(registered_host())
-    builder.build_template()
+    preset = builder.get_template_preset()
+    builder.build_template(preset=preset)
 
 
 def update_workfile_template(*args) -> None:

--- a/client/ayon_max/api/workfile_template_builder.py
+++ b/client/ayon_max/api/workfile_template_builder.py
@@ -222,7 +222,7 @@ def trigger_on_app_launch() -> None:
     """
     builder = MaxTemplateBuilder(registered_host())
     preset = builder.get_template_preset()
-    if preset.execute_on_new_file and preset.execute_on_app_launch:
+    if preset.execute_on_new_file:
         builder.trigger_on_new_file()
     else:
         builder.trigger_on_app_launch()

--- a/package.py
+++ b/package.py
@@ -7,6 +7,6 @@ project_can_override_addon_version = True
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">=1.8.0",
+    "core": ">=1.9.9",
 }
 ayon_compatible_addons = {}

--- a/server/settings/templated_workfile_build.py
+++ b/server/settings/templated_workfile_build.py
@@ -36,6 +36,14 @@ class TemplatedWorkfileProfileModel(BaseSettingsModel):
         True,
         title="Create first version"
     )
+    execute_on_new_file: bool = SettingsField(
+        False,
+        title="Always apply to empty scene"
+    )
+    execute_on_app_launch: bool = SettingsField(
+        False,
+        title="Apply on application launch"
+    )
 
 
 class TemplatedWorkfileBuildModel(BaseSettingsModel):

--- a/server/settings/templated_workfile_build.py
+++ b/server/settings/templated_workfile_build.py
@@ -31,18 +31,19 @@ class TemplatedWorkfileProfileModel(BaseSettingsModel):
     )
     keep_placeholder: bool = SettingsField(
         False,
-        title="Keep placeholders")
-    create_first_version: bool = SettingsField(
-        True,
-        title="Create first version"
+        title="Keep placeholders"
     )
     execute_on_new_file: bool = SettingsField(
         False,
-        title="Always apply to empty scene"
+        title="Apply to New Scene"
     )
     execute_on_app_launch: bool = SettingsField(
         False,
-        title="Apply on application launch"
+        title="Apply on 3dsmax launch"
+    )
+    create_first_version: bool = SettingsField(
+        True,
+        title="Save first workfile version"
     )
 
 


### PR DESCRIPTION
## Changelog Description
This PR is to add some more options to allow templated builder to be enabled in several scenarios: 
1. Template Always apply to empty scene (act as 'new file' template)
2. Apply on application launch if no workfile exists yet
## Additional info
Resolve https://github.com/ynput/ayon-core/issues/1040
Links to https://github.com/ynput/ayon-core/pull/1907

## Testing notes:
1. Build workfile as followed in the host PR above

