### PR TITLE
Compatibility for 3dsmax 2027

### DIFF
--- a/client/ayon_max/api/menu.py
+++ b/client/ayon_max/api/menu.py
@@ -235,7 +235,23 @@ class AYONMenu(object):
 
     def workfiles_callback(self):
         """Callback to show Workfiles tool."""
-        host_tools.show_workfiles(parent=self.main_widget)
+        workfiles_tool = host_tools.show_workfiles(parent=self.main_widget)
+        # Refresh after the UI has finished its initial setup cycle.
+        if lib.get_max_version() >= 2027:
+            QtCore.QTimer.singleShot(
+                100,
+                lambda tool=workfiles_tool: self._refresh_workfiles_tool(tool)
+            )
+
+    def _refresh_workfiles_tool(self, workfiles_tool):
+        """Refresh the Workfiles tool after it has been created or without any
+        cache data for _refresh.
+
+        Args:
+            workfiles_tool (QtWidgets.QWidget): The workfiles tool widget to refresh.
+        """
+        if not getattr(workfiles_tool, "_refresh", None):
+            workfiles_tool.refresh()
 
     def resolution_callback(self):
         """Callback to reset scene resolution"""

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -22,7 +22,6 @@ from ayon_core.pipeline import (
     AYON_CONTAINER_ID,
     get_current_project_name
 )
-from ayon_max.api.menu import AYONMenu
 from ayon_core.settings import get_project_settings
 from ayon_max.api import lib
 from ayon_max.api.plugin import MS_CUSTOM_ATTRIB
@@ -158,6 +157,8 @@ class MaxHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def _deferred_menu_creation(self):
         self.log.info("Building menu ...")
+        # Import menu lazily so Qt bindings are resolved after Max runtime init.
+        from ayon_max.api.menu import AYONMenu
         self.menu = AYONMenu()
 
     @staticmethod
@@ -280,7 +281,7 @@ def on_init():
     last_workfile = os.getenv("AYON_LAST_WORKFILE")
     if os.getenv("AVALON_OPEN_LAST_WORKFILE") != "1"  \
         or not os.path.exists(last_workfile):
-            lib.set_context_settings()
+        lib.set_context_settings()
 
 
 def on_new():

--- a/client/ayon_max/api/pipeline.py
+++ b/client/ayon_max/api/pipeline.py
@@ -278,9 +278,8 @@ def get_containers() -> List:
 def on_init():
     if not os.path.exists(rt.ColorPipelineMgr.OCIOConfigPath):
         lib.reset_colorspace()
-    last_workfile = os.getenv("AYON_LAST_WORKFILE")
-    if os.getenv("AVALON_OPEN_LAST_WORKFILE") != "1"  \
-        or not os.path.exists(last_workfile):
+    last_workfile = os.getenv("AYON_LAST_WORKFILE") or ""
+    if os.getenv("AVALON_OPEN_LAST_WORKFILE") != "1" or not os.path.exists(last_workfile):
         lib.set_context_settings()
 
 

--- a/client/ayon_max/hooks/inject_python.py
+++ b/client/ayon_max/hooks/inject_python.py
@@ -2,13 +2,12 @@
 """Pre-launch hook to inject python environment."""
 import os
 from ayon_applications import PreLaunchHook, LaunchTypes
-from ayon_max import MAX_HOST_DIR
 
 
 class InjectPythonPath(PreLaunchHook):
     """Inject AYON environment to 3dsmax.
 
-    Note that this works in combination with 3dsmax startup script that
+    Note that this works in combination whit 3dsmax startup script that
     is translating it back to PYTHONPATH for cases when 3dsmax drops PYTHONPATH
     environment.
 
@@ -18,13 +17,4 @@ class InjectPythonPath(PreLaunchHook):
     launch_types = {LaunchTypes.local}
 
     def execute(self):
-        pythonpath_value = self.launch_context.env.get("PYTHONPATH")
-        if pythonpath_value is None:
-            pythonpath_value = os.environ.get("PYTHONPATH", "")
-
-        paths = [path for path in pythonpath_value.split(os.pathsep) if path]
-        addon_client_path = os.path.join(MAX_HOST_DIR, "client")
-        if addon_client_path not in paths:
-            paths.append(addon_client_path)
-
-        self.launch_context.env["MAX_PYTHONPATH"] = os.pathsep.join(paths)
+        self.launch_context.env["MAX_PYTHONPATH"] = os.environ["PYTHONPATH"]

--- a/client/ayon_max/hooks/inject_python.py
+++ b/client/ayon_max/hooks/inject_python.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""Pre-launch hook to inject python environment."""
+import os
+from ayon_applications import PreLaunchHook, LaunchTypes
+from ayon_max import MAX_HOST_DIR
+
+
+class InjectPythonPath(PreLaunchHook):
+    """Inject AYON environment to 3dsmax.
+
+    Note that this works in combination whit 3dsmax startup script that
+    is translating it back to PYTHONPATH for cases when 3dsmax drops PYTHONPATH
+    environment.
+
+    Hook `GlobalHostDataHook` must be executed before this hook.
+    """
+    app_groups = {"3dsmax", "adsk_3dsmax"}
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+        pythonpath_value = self.launch_context.env.get("PYTHONPATH")
+        if pythonpath_value is None:
+            pythonpath_value = os.environ.get("PYTHONPATH", "")
+
+        paths = [path for path in pythonpath_value.split(os.pathsep) if path]
+        addon_client_path = os.path.join(MAX_HOST_DIR, "client")
+        if addon_client_path not in paths:
+            paths.append(addon_client_path)
+
+        self.launch_context.env["MAX_PYTHONPATH"] = os.pathsep.join(paths)

--- a/client/ayon_max/hooks/inject_python.py
+++ b/client/ayon_max/hooks/inject_python.py
@@ -8,7 +8,7 @@ from ayon_max import MAX_HOST_DIR
 class InjectPythonPath(PreLaunchHook):
     """Inject AYON environment to 3dsmax.
 
-    Note that this works in combination whit 3dsmax startup script that
+    Note that this works in combination with 3dsmax startup script that
     is translating it back to PYTHONPATH for cases when 3dsmax drops PYTHONPATH
     environment.
 

--- a/client/ayon_max/startup/startup.py
+++ b/client/ayon_max/startup/startup.py
@@ -11,17 +11,15 @@ for path in os.getenv("MAX_PYTHONPATH", "").split(os.pathsep):
     if os.path.isdir(norm_path) and norm_path not in new_python_paths:
         new_python_paths.append(norm_path)
 
-existing_pythonpath = []
-for path in os.environ.get("PYTHONPATH", "").split(os.pathsep):
-    if not path:
-        continue
-    norm_path = os.path.normpath(path)
-    if os.path.isdir(norm_path) and norm_path not in existing_pythonpath:
-        existing_pythonpath.append(norm_path)
+existing_pythonpath = [
+    p for p in os.environ.get("PYTHONPATH", "").split(os.pathsep) if p
+]
+existing_pythonpath_norm = {os.path.normpath(p) for p in existing_pythonpath}
 
 for path in new_python_paths:
-    if path not in existing_pythonpath:
+    if path not in existing_pythonpath_norm:
         existing_pythonpath.insert(0, path)
+        existing_pythonpath_norm.add(path)
 
     # 3ds Max 2027 may ignore PYTHONPATH on startup; update runtime import path.
     if path not in sys.path:

--- a/client/ayon_max/startup/startup.py
+++ b/client/ayon_max/startup/startup.py
@@ -1,5 +1,37 @@
-from ayon_max.api import MaxHost
-from ayon_core.pipeline import install_host
+import os
+import sys
+
+# For 3ds Max 2027, we need to ensure that the PYTHONPATH is set
+# correctly before importing any modules.
+new_python_paths = []
+for path in os.getenv("MAX_PYTHONPATH", "").split(os.pathsep):
+    if not path:
+        continue
+    norm_path = os.path.normpath(path)
+    if os.path.isdir(norm_path) and norm_path not in new_python_paths:
+        new_python_paths.append(norm_path)
+
+existing_pythonpath = []
+for path in os.environ.get("PYTHONPATH", "").split(os.pathsep):
+    if not path:
+        continue
+    norm_path = os.path.normpath(path)
+    if os.path.isdir(norm_path) and norm_path not in existing_pythonpath:
+        existing_pythonpath.append(norm_path)
+
+for path in new_python_paths:
+    if path not in existing_pythonpath:
+        existing_pythonpath.insert(0, path)
+
+    # 3ds Max 2027 may ignore PYTHONPATH on startup; update runtime import path.
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+os.environ["PYTHONPATH"] = os.pathsep.join(existing_pythonpath)
+
+
+from ayon_max.api import MaxHost  # noqa: E402
+from ayon_core.pipeline import install_host  # noqa: E402
 
 host = MaxHost()
 install_host(host)


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the AYON 3dsmax addon being compatible with 2027.
Resolve https://github.com/ynput/ayon-3dsmax/issues/156, https://github.com/ynput/ayon-3dsmax/issues/158

## Additional review information
Tested with farm rendering and see if anything hits the wall.

## Testing notes:
1. Launch Max
2. AYON plugins and tools are installed and can be used as usual.
